### PR TITLE
Removed "Tags:" label from posts if no tags present

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -14,6 +14,7 @@
   </div>
   <div class="row">
     <div class="col-10">
+      {% if post.tags %}
       <p>
         <strong>Tags:</strong>
         {% for tag in post.tags %}
@@ -21,6 +22,7 @@
             {{ tag.name }}</a>{{ ',' if not loop.last }}
         {% endfor %}
       </ul>
+      {% endif %}
     </div>
   </div>
   <div class="row">

--- a/templates/post.html
+++ b/templates/post.html
@@ -12,19 +12,19 @@
       <h1>{{ post.title.rendered | safe }}</h1>
     </div>
   </div>
+  {% if post.tags %}
   <div class="row">
     <div class="col-10">
-      {% if post.tags %}
       <p>
         <strong>Tags:</strong>
         {% for tag in post.tags %}
           <a href="/tag/{{ tag.slug }}">
             {{ tag.name }}</a>{{ ',' if not loop.last }}
         {% endfor %}
-      </ul>
-      {% endif %}
+      </p>
     </div>
   </div>
+  {% endif %}
   <div class="row">
     <div class="col-10">
       <ul class="p-inline-list">


### PR DESCRIPTION
## Done

- Added an if statement that determined that the 'Tags:' label should only show if the post contains tags


## QA

- Check that the 'Tags:' label is still present on posts with tags (e.g. [http://0.0.0.0:8023/2017/10/09/lxd-weekly-status-18/](http://0.0.0.0:8023/2017/10/09/lxd-weekly-status-18/)
- Check that the 'Tags:' label is not present on posts without tags (e.g. [http://0.0.0.0:8023/2017/10/09/lxd-weekly-status-16/](http://0.0.0.0:8023/2017/10/09/lxd-weekly-status-16/)


## Issue / Card

Fixes #3 