### PR TITLE
Add user and date to the post listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import json
 import humanize
 import requests
 import requests_cache
-from dateutil import parser, relativedelta
+from dateutil import parser
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 from urllib.parse import urlsplit

--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 import datetime
 import flask
 import json
+import humanize
 import requests
 import requests_cache
+from dateutil import parser, relativedelta
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 from urllib.parse import urlsplit
@@ -104,7 +106,7 @@ def _get_groups_by_slug(slugs=[]):
 
 
 def _get_posts(groups=[], tags=[], page=None):
-    api_url = '{api_url}/posts?embed&page={page}'.format(
+    api_url = '{api_url}/posts?_embed&page={page}'.format(
         api_url=INSIGHTS_URL,
         page=str(page or 1),
     )
@@ -192,6 +194,9 @@ def _normalise_post(post):
     link = post['link']
     path = urlsplit(link).path
     post['relative_link'] = path
+    post['formatted_date'] = humanize.naturaldate(
+        parser.parse(post['date'])
+    )
     post = _embed_post_data(post)
     return post
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ requests==2.18.4
 requests-cache==0.4.13
 urllib3==1.22
 Werkzeug==0.12.2
+humanize==0.5.1
+python-dateutil==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
 Flask==0.12.2
+humanize==0.5.1
 idna==2.6
 itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
+python-dateutil==2.6.1
 requests==2.18.4
 requests-cache==0.4.13
 urllib3==1.22
 Werkzeug==0.12.2
-humanize==0.5.1
-python-dateutil==2.6.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,17 +12,12 @@
     </div>
   </div>
 
-  {#
-  {{ current_page }}
-  {{ total_pages }}
-  {{ total_posts }}
-  #}
-
   {% for post in posts %}
     <div class="p-strip is-shallow is-bordered">
       <div class="row">
         <div class="col-8">
           <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
+          <p>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.formatted_date }}</p>
           <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
         </div>
       </div>


### PR DESCRIPTION
##  Done
Added the `humanize` and `dateutil` to display the date of the post on the listing page. Removed some commented out template variables.

## QA
- Pull branch
- Run `./run`
- Go to http://0.0.0.0:8023/
- Check that the post listing displays `By {{ author }}, {{ date }}`

## Details
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/15