### PR TITLE
Redirect to 404.html when group is unknown

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,6 +202,15 @@ def index(category=[]):
     groups = []
     if category:
         groups = _get_groups_by_slug(slugs=category)
+        if not groups:
+            groups.append({
+                "id": -1,
+                "name": category
+            })
+
+            return flask.render_template(
+                '404.html'
+            )
 
     page = flask.request.args.get('page')
     posts, metadata = _get_posts(

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block body %}
+<div>
+    404
+</div>
+{% endblock %}


### PR DESCRIPTION
# Summary
Redirects to a 404.html when category is unknown. 
/!\ I pushed a `404.html` just for the demo, I will remove it from the commit once https://github.com/canonical-websites/insights.ubuntu.com/issues/27 is done

# Behavior
# Actual Behavior

- `./run`
- [0.0.0.0:8023/asdf/](http://0.0.0.0:8023/asdf/)
- Displays a page with all the posts

# Expected Behavior

- `./run`
- [0.0.0.0:8023/asdf/](http://0.0.0.0:8023/asdf/)
- Displays a 404 page or a Unknown category page

# Issues

- Merge once https://github.com/canonical-websites/insights.ubuntu.com/issues/27 is done
- Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/28