### PR TITLE
Added RTP divs across the site

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,12 +171,23 @@ def _get_tag_details_from_post(post_id):
     return tags
 
 
+def _get_topic_details_from_post(post_id):
+    api_url = '{api_url}/topic?post={post_id}'.format(
+        api_url=INSIGHTS_URL,
+        post_id=post_id,
+    )
+    response = _get_from_cache(api_url)
+    topics = json.loads(response.text)
+    return topics
+
+
 def _embed_post_data(post):
     if '_embedded' not in post:
         return post
     embedded = post['_embedded']
     post['author'] = _normalise_user(embedded['author'][0])
     post['tags'] = _get_tag_details_from_post(post['id'])
+    post['topics'] = _get_topic_details_from_post(post['id'])
     return post
 
 

--- a/static/sass/_pattern_rtp.scss
+++ b/static/sass/_pattern_rtp.scss
@@ -1,0 +1,7 @@
+@mixin insights-p-rtp {
+  .rtp-banner {
+    &:empty {
+      display: none;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,8 +1,8 @@
-@charset "UTF-8";
+@charset 'UTF-8';
 
-// import vanilla-framework
 @import 'vanilla-framework/scss/build';
-@import '_pattern_social-share';
-
+@import 'pattern_social-share';
+@import 'pattern_rtp';
 
 @include insights-p-social-share;
+@include insights-p-rtp;

--- a/templates/group.html
+++ b/templates/group.html
@@ -10,6 +10,7 @@
             {{ category.name }}
           {% endif %}
         </h1>
+        <div id="rtp-banner" class="rtp-banner"></div>
       </div>
     </div>
   </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -73,6 +73,17 @@
       {{ post.content.rendered | safe }}
     </div>
     <div class="col-4">
+      <div class="p-card" id="rtp-{{ post.topics[0].slug }}">
+        <h3>
+          <a href="http://www.ubuntu.com/cloud" class="p-link--external">
+            Ubuntu cloud
+          </a>
+        </h3>
+        <p>
+          Ubuntu offers all the training, software infrastructure, tools,
+          services and support you need for your public and private clouds.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -4,6 +4,7 @@
     <div class="row">
       <div class="col-8">
         <h1 class="u-no-margin--bottom">{{ tag.name }}</h1>
+        <div id="rtp-banner" class="rtp-banner"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done
Added RTP divs to the places they apart in the current site. This content is controlled by an external source. 

## QA
- Check that the post page has a card on the right with default content
- Check a group and tag page. You should see no difference but there will be an empty div with an id of `rtp-banner`

## Details
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/18