### PR TITLE
Added 1rem padding to code block margin-top

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,3 +6,17 @@
 
 @include insights-p-social-share;
 @include insights-p-rtp;
+
+// Bug fixes
+// Each of the the rules below are bug fixes which need to be addressed further upstream
+// either at theme level or in Vanilla Framework directly.
+//
+// Before any feature branch is merged, these bugs should be raised in their
+// respective repos and referenced here, accompanied with a breif description of
+// the bug
+
+/// XXX Code block top margin
+/// Temporary fix for https://github.com/canonical-websites/insights.ubuntu.com/issues/5
+pre {
+  margin-top: 1rem;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -17,6 +17,7 @@
 
 /// XXX Code block top margin
 /// Temporary fix for https://github.com/canonical-websites/insights.ubuntu.com/issues/5
+/// Vanilla issue https://github.com/vanilla-framework/vanilla-framework/issues/1385
 pre {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Done

- Added 1rem padding to code block margin-top (temporary fix until addressed upstream)


## QA

- Check that code blocks have adequate spacing above and below (e.g. [here](http://insights.ubuntu.com-pr-37.run.demo.haus/2017/05/09/ros-production-create-ubuntu-core-image-with-snap-preinstalled-55/))


## Issue / Card

Fixes #5 