### PR TITLE
Added team pages and team dropdown on main nav

### DIFF
--- a/data/topics.json
+++ b/data/topics.json
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "Design",
+        "slug": "design",
+        "subtitle": "Branding and Web Development",
+        "description": "Learn about the Design team and what they work on, including Ubuntu and Canonical branding, Vanilla and product photography.",
+        "url": "https://design.ubuntu.com",
+        "logo_url": "https://assets.ubuntu.com/v1/70041419-vanilla-framework.png",
+        "hero_url": "https://assets.ubuntu.com/v1/78b7c44a-hero-dots.png"
+    },
+    {
+        "name": "Juju",
+        "slug": "juju",
+        "subtitle": "Operate big software at scale on any cloud",
+        "description": "Exploring Juju and JAAS – open source application modelling tools used to deploy, configure, scale and operate your software on public and private clouds.",
+        "url": "https://jujucharms.com",
+        "logo_url": "https://assets.ubuntu.com/v1/31c507a5-image-juju.svg",
+        "hero_url": "https://assets.ubuntu.com/v1/e8b86f15-Juju-Visual-Screen.png?w=576"
+    },
+    {
+        "name": "MAAS",
+        "slug": "maas",
+        "subtitle": "Machine-as-a-Service",
+        "description": "All you need to know about MAAS – the smartest way to manage bare metal. Big data, private cloud, PAAS and HPC all thrive on MAAS.",
+        "url": "https://maas.io",
+        "logo_url": "https://assets.ubuntu.com/v1/5f3d3c45-maas-logo-cropped.svg",
+        "hero_url": "https://assets.ubuntu.com/v1/e6c6b98f-Maas-Visual-Screen.png?w=576"
+    },
+    {
+        "name": "Snappy",
+        "slug": "snappy",
+        "subtitle": "A ‘snap’ is a universal Linux package",
+        "description": "News from the Snappy team – articles on application architecture, prototyping, packaging paradigms and more.",
+        "url": "https://snapcraft.io",
+        "logo_url": "https://assets.ubuntu.com/v1/3075aa19-snappy-icon.svg",
+        "hero_url": "https://assets.ubuntu.com/v1/a91f36a8-Snapcraft-Visual-Screen.png?w=576"
+    }
+]

--- a/static/js/aria-controls.js
+++ b/static/js/aria-controls.js
@@ -1,0 +1,42 @@
+(function() {
+
+  function accordionToggles(tabCtrl) {
+    let toggles = Array.prototype.slice.call(
+      document.querySelectorAll(tabCtrl)
+    );
+
+    function toggle (toggle, open) {
+      let button = toggle.getAttribute('aria-controls');
+      let panel = document.querySelector(button);
+
+      if (open) {
+        panel.setAttribute('aria-hidden', false);
+        toggle.setAttribute('aria-expanded', true);
+      } else {
+        panel.setAttribute('aria-hidden', true);
+        toggle.setAttribute('aria-expanded', false);
+      }
+    }
+
+    function toggleAll (event) {
+      let target = event.target;
+
+      // Filter through all toggles and toggle visiblity
+      toggles.forEach(panel => {
+        if (panel !== target) {
+          toggle(panel);
+        }
+      });
+
+      // Target toggle to be shown
+      let targetOpen = target.getAttribute('aria-expanded');
+      targetOpen === 'true' ? toggle(target, false) : toggle(target, true);
+    }
+
+    toggles.forEach(toggle => {
+      toggle.addEventListener('click', toggleAll);
+    });
+  }
+
+  accordionToggles('.p-accordion__tab');
+})()

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -21,3 +21,106 @@
 pre {
   margin-top: 1rem;
 }
+
+/// XXX Navigation dropdown
+/// Temporary implementation of nav dropdown until implemented in Vanilla
+@media (min-width: $breakpoint-medium + 1) {
+  .p-navigation__link:hover .hover-menu {
+    display: block;
+  }
+}
+
+.p-navigation .p-navigation__nav ul li:hover ul::after {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAICAYAAAD5nd/tAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QYODgYVPPJJpQAAAT9JREFUKM+dkD9IAnEUx7+/IkVxFaxoKYxIWhqKwJw0JAJ315Yac8+1tUFo6HCp34XRdRp11z+J4BzckqShPzdEQ5G/EhPO6V5Tcg3G0QcePHjvffjygB4oXAIApFMxyPlcWM7nwulU7NfMNQqXGABsZNcCCpcKtapBtapBCpcK2fXlAAAcy3vMlUxTdgEAO9ubybPiPjWFoE6nQ5ZlUfNDULl0RAdSPuncddL30+gnCgOAlngLaocyn4nG9fmFJXj9fhARAMDr82MuEcfk7LSuFQu8DTvovO1SuTxlAKCqPFO5Ov/6FIIsy/qzROOdrst6S1V5xunomo0LrT4yOh4JDg6BMXfvIdvGs/mExutLPZpYnAIAdmNUVuwBbI1NRODxePEf2u0WHu9u4ev3rTLTfKBQaNh1qp5piWCa9/gGBheo3r6AmYcAAAAASUVORK5CYII=') $sp-large bottom no-repeat;
+  content: '';
+  display: block;
+  height: $sp-x-small;
+  left: 0;
+  position: absolute;
+  top: -$sp-x-small;
+  width: 150px;
+  z-index: 999;
+}
+
+.hover-menu {
+  background: $color-light;
+  border: 1px solid $color-mid-light;
+  border-radius: 10px;
+  box-shadow: 0 2px 2px -1px $color-mid-light;
+  display: none;
+  float: none;
+  margin: 0;
+  padding: $sp-x-small 0 $sp-medium;
+  position: absolute;
+  top: 50px;
+  width: 150px;
+  z-index: 1;
+
+  li {
+    font-size: .875rem;
+    padding: $sp-x-small $sp-small 0 $sp-small;
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+  }
+
+  a {
+    color: $color-dark;
+  }
+}
+
+/// XXX Small screen accordion
+/// Temporary fix until small screen nav accordion implemented in Vanilla
+.p-accordion__tab {
+  background-color: #f7f7f7;
+  font-size: 0.875rem;
+  padding: 1rem 2.5rem 1rem 8px;
+}
+
+.p-accordion__panel {
+  border: none;
+  padding: 0;
+
+  >.p-navigation__links>.p-navigation__link {
+    padding-left: 1rem;
+  }
+}
+
+
+.p-heading-icon__title {
+  font-size: 2.5rem;
+}
+
+.card-image {
+  box-shadow: 0 1px 5px 1px rgba(51, 51, 51, 0.2);
+  margin-top: 1.5rem !important;
+  max-height: 100%;
+}
+
+@media (min-width: $breakpoint-medium + 1) {
+  .card-image {
+    margin-top: 2.5rem !important;
+  }
+}
+
+.design-image {
+  padding-top: 1.5rem;
+  max-height: 100%;
+}
+
+@media (min-width: $breakpoint-medium + 1) {
+  .design-image {
+    padding-top: 2.5rem;
+  }
+}
+
+.header-strip {
+  height: inherit;
+}
+
+@media (min-width: $breakpoint-medium + 1) {
+  .header-strip {
+    height: 320px;
+  }
+}

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block body %}
+
   <div class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
@@ -14,14 +15,7 @@
       </div>
     </div>
   </div>
-  {% for post in posts %}
-    <div class="p-strip is-shallow is-bordered">
-      <div class="row">
-        <div class="col-8">
-          <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
-          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
-        </div>
-      </div>
-    </div>
-  {% endfor %}
+
+  {% include "posts.html" %}
+
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,37 +1,38 @@
 {% extends "layout.html" %}
 {% block body %}
-  <div class="p-strip--accent">
-    <div class="row">
-      <div class="col-8">
-        <h1>Ubuntu Insights</h1>
-        <p>Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.</p>
-      </div>
-      <div class="col-4 u-align--center">
-        <img src="https://assets.ubuntu.com/v1/e2047558-pictogram-knowledge-orange-white-background.svg" width="200" alt="" />
-      </div>
-    </div>
-  </div>
-  {% if featured_post %}
-  <div class="p-strip is-shallow is-bordered">
-    <div class="row">
-      <div class="col-8">
-        <h3 class="p-heading--four">Featured article</h3>
-        <h2 class="p-heading-three"><a href="{{ featured_post.relative_link }}">{{ featured_post.title.rendered | safe }}</a></h2>
-        <p class="u-no-padding--bottom">{{ featured_post.excerpt.rendered | safe }}</p>
-      </div>
-    </div>
-  </div>
-  {% endif %}
 
-  {% for post in posts %}
-    <div class="p-strip is-shallow is-bordered">
-      <div class="row">
-        <div class="col-8">
-          <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
-          <p>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.formatted_date }}</p>
-          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
-        </div>
-      </div>
+<div class="p-strip--accent u-image-position">
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h1 class="p-heading--one">
+        Ubuntu Insights
+      </h1>
+      <p class="p-heading--five">
+        Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.
+      </p>
     </div>
-  {% endfor %}
+    <div class="col-5 prefix-1 u-align--center">
+      <img src="https://assets.ubuntu.com/v1/e2047558-pictogram-knowledge-orange-white-background.svg"
+        class="u-hidden--small"
+        width="200"
+        alt="" />
+    </div>
+  </div>
+</div>
+
+{% if featured_post %}
+<div class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--four">Featured article</h3>
+      <h2 class="p-heading--three"><a href="{{ featured_post.relative_link }}">{{ featured_post.title.rendered | safe }}</a></h2>
+      <p>By <a href="{{ featured_post.author.relative_link }}" title="More about {{ featured_post.author.name }}">{{ featured_post.author.name }}</a>, {{ featured_post.formatted_date }}</p>
+      <p class="u-no-padding--bottom">{{ featured_post.excerpt.rendered | safe }}</p>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+  {% include "posts.html" %}
+
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -60,11 +60,45 @@
           <span class="u-off-screen">
             <a href="#main-content">Jump to main content</a>
           </span>
-          <ul class="p-navigation__links">
-            <li class="p-navigation__link"><a href="/cloud-and-server">Cloud and server</a></li>
+          <ul class="p-navigation__links u-hide--small">
+            <li class="p-navigation__link"><a href="/cloud-and-server/">Cloud and server</a></li>
             <li class="p-navigation__link"><a href="/internet-of-things/">IoT</a></li>
             <li class="p-navigation__link"><a href="/desktop/">Desktop</a></li>
             <li class="p-navigation__link"><a href="/press-centre/">Press centre</a></li>
+            <li class="p-navigation__link">
+              <a href="#">Topics</a>
+              <ul class="hover-menu">
+                <li><a href="/topics/design/">Design</a></li>
+                <li><a href="/topics/juju/">Juju</a></li>
+                <li><a href="/topics/maas/">MAAS</a></li>
+                <li><a href="/topics/snappy/">Snappy</a></li>
+              </ul>
+            </li>
+          </ul>
+          <!-- Mobile Nav -->
+          <ul class="p-navigation__links u-hide--medium u-hide--large">
+            <li class="p-accordion__group">
+              <button class="p-accordion__tab" id="categories-tab" role="tab" aria-controls="#categories" aria-expanded="false">Categories</button>
+              <div class="p-accordion__panel" id="categories" role="tabpanel" aria-hidden="true" aria-labelledby="categories-tab">
+                <ul class="p-navigation__links">
+                  <li class="p-navigation__link"><a href="/cloud-and-server/">Cloud and server</a></li>
+                  <li class="p-navigation__link"><a href="/internet-of-things/">IoT</a></li>
+                  <li class="p-navigation__link"><a href="/desktop/">Desktop</a></li>
+                  <li class="p-navigation__link"><a href="/press-centre/">Press centre</a></li>
+                </ul>
+              </div>
+            </li>
+            <li class="p-accordion__group">
+              <button class="p-accordion__tab" id="topics-tab" role="tab" aria-controls="#topics" aria-expanded="false">Teams</button>
+              <div class="p-accordion__panel" id="teams" role="tabpanel" aria-hidden="true" aria-labelledby="teams-tab">
+                <ul class="p-navigation__links">
+                  <li class="p-navigation__link"><a href="/topics/design/">Design</a></li>
+                  <li class="p-navigation__link"><a href="/topics/juju/">Juju</a></li>
+                  <li class="p-navigation__link"><a href="/topics/maas/">MAAS</a></li>
+                  <li class="p-navigation__link"><a href="/topics/snappy/">Snappy</a></li>
+                </ul>
+              </div>
+            </li>
           </ul>
         </nav>
       </div>
@@ -93,7 +127,7 @@
       </footer>
     </div>
     <script src="/static/js/modules/cookie-policy.js"></script>
-
+    <script src="/static/js/aria-controls.js"></script>
     <script src="/static/js/modules/global.js"></script>
     <script>
       var options = {

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,0 +1,15 @@
+{% block posts %}
+
+  {% for post in posts %}
+    <div class="p-strip is-shallow is-bordered">
+      <div class="row">
+        <div class="col-8">
+          <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
+          <p>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.formatted_date }}</p>
+          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+  
+{% endblock %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block body %}
+
   <div class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
@@ -8,14 +9,7 @@
       </div>
     </div>
   </div>
-  {% for post in posts %}
-    <div class="p-strip is-shallow is-bordered">
-      <div class="row">
-        <div class="col-8">
-          <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
-          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
-        </div>
-      </div>
-    </div>
-  {% endfor %}
+
+  {% include "posts.html" %}
+
 {% endblock %}

--- a/templates/topics.html
+++ b/templates/topics.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% block body %}
+
+  <div class="p-strip is-shallow is-bordered u-image-position" style="overflow: hidden;">
+    <div class="row header-strip u-equal-height">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" src="{{ topic.logo_url }}" alt=""/>
+            <h1 class="p-heading--one p-heading-icon__title">{{ topic.name }}</h1>
+          </div>
+          <h2 class="p-heading--two">{{ topic.subtitle }}</h2>
+          <p class="p-heading--five">{{ topic.description }}</p>
+        </div>
+          <p>
+            <a class="p-link--external" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
+          </p>
+        </ul>
+      </div>
+      <div class="col-5 prefix-1">
+        <img src="{{ topic.hero_url }}"
+        class="{% if topic.name == 'Design' %}design-image{% else %}card-image{% endif %} u-hidden--small u-image-position--bottom"
+        alt="" />
+      </div>
+    </div>
+  </div>
+
+  {% include "posts.html" %}
+
+{% endblock %}


### PR DESCRIPTION
## Done

- Added an entry to the main nav ('Teams') that uses the same dropdown functionality as the Ubuntu site
- Added teams.html template that renders team pages with relevant header details and articles


## QA

- Check that the Teams button is in the nav, and each link in the dropdown takes you to the right place
- Check that the header details and articles that load are relevant to the team
- Check my Python code....


## Issue / Card
Fixes #33 
