### PR TITLE
Add marketo newsletter sign up form

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -105,7 +105,8 @@
             return "Please enter a valid email address";
           }
           </script>
-
+          {% if digest == 'true' %}<h1>yeah boy</h1>{% endif %}
+          {{ digest }}
           <form class='p-form mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
             <h2>Sign up for email updates</h2>
             <p>Choose the topics you're interested in</p>
@@ -123,6 +124,10 @@
                 <li class="p-list__item">
                   <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="yes"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
                   <label for="insightsiot">Internet of Things</label>
+                </li>
+                <li class="p-list__item">
+                    <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="yes" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
+                    <label for="insightstutorials">Tutorials</label>
                 </li>
               </ul>
 
@@ -145,7 +150,7 @@
               <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
               <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
               <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-              <input type="hidden" name="ret" value="<?php $theurl = rtrim(get_permalink(),'/'); echo $theurl; ?>?digest=true" />
+              <input type="hidden" name="ret" value="http://0.0.0.0:8023{{request.path}}?digest=true" />
               <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
               <input type="hidden" name="kw" value=""/>
               <input type="hidden" name="cr" value=""/>

--- a/templates/post.html
+++ b/templates/post.html
@@ -85,27 +85,12 @@
         </p>
       </div>
     </div>
-
+  </div>
+</div>
+<div class="p-strip is-shallow">
     <div class="row">
       <div class="col-8">
-        <script>
-        function fieldValidate(field) {
-          /* call Mkto.setError(field, message) and return false to mark a field value invalid */
-          /* return 'skip' to bypass the built-in validations */
-          return true;
-        }
-        function getRequiredFieldMessage(domElement, label) {
-          return "This field is required";
-        }
-        function getTelephoneInvalidMessage(domElement, label) {
-          return "Please enter a valid telephone number";
-        }
-        function getEmailInvalidMessage(domElement, label) {
-          return "Please enter a valid email address";
-        }
-        </script>
-
-        <form class='p-form mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
+        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
           <h2>Sign up for email updates</h2>
           <p>Choose the topics you're interested in</p>
             <ul class="p-list">
@@ -129,9 +114,9 @@
               </li>
             </ul>
 
-          <div class='mktoFormCol'>
-            <label class="off-left mktoLabel" for='Email'>Your email</label>
-            <input type="text" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required>
+          <div class='mktFormReq mktField'>
+            <label for="Email" class="mktoLabel">Work email: <span>*</span></label>
+            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
           </div>
 
           <div class="mktField mktLblRight">
@@ -142,23 +127,29 @@
           </div>
 
           <div>
-            <span style="display:none;"><input type="text" name="_marketo_comments" value=""></span>
             <span class='mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
             <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
             <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-            <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
+            <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
             <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="http://insights.ubuntu.com{{request.path}}?digest=true" />
+            <input type="hidden" name="ret" value="{{request.host}}{{request.path}}?digest=true" />
             <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-            <input type="hidden" name="kw" value=""/>
-            <input type="hidden" name="cr" value=""/>
-            <input type="hidden" name="searchstr" value=""/>
-            <input type="hidden" name="_mkt_disp" value="return"/>
-            <input type="hidden" name="_mkt_trk" value=""/>
+            <input name="kw" value="" type="hidden">
+            <input name="cr" value="" type="hidden">
+            <input name="searchstr" value="" type="hidden">
+            <input name="_mkt_disp" value="return" type="hidden">
+            <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
           </div>
         </form>
       </div>
-      <script language="JavaScript" src="https://app.marketo.com/js/public/jquery-latest.min.js" type="text/javascript"></script>
+      <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+      <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+      <script>
+      $("#mktoForm_1212").validate({
+          errorElement: "span",
+          errorClass: "mktFormMsg mktError"
+      });
+      </script>
     </div>
   </div>
 </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -85,6 +85,79 @@
         </p>
       </div>
     </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-card">
+          <script>
+          function fieldValidate(field) {
+            /* call Mkto.setError(field, message) and return false to mark a field value invalid */
+            /* return 'skip' to bypass the built-in validations */
+            return true;
+          }
+          function getRequiredFieldMessage(domElement, label) {
+            return "This field is required";
+          }
+          function getTelephoneInvalidMessage(domElement, label) {
+            return "Please enter a valid telephone number";
+          }
+          function getEmailInvalidMessage(domElement, label) {
+            return "Please enter a valid email address";
+          }
+          </script>
+
+          <form class='p-form mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
+            <h2>Sign up for email updates</h2>
+            <p>Choose the topics you're interested in</p>
+              <ul class="p-list">
+                <li class="p-list__item">
+                <div>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="yes" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
+                  <label for="insightscloudserver">Cloud and server</label>
+                </div>
+                </li>
+                <li class="p-list__item">
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="yes"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
+                  <label for="insightsdesktop">Desktop</label>
+                </li>
+                <li class="p-list__item">
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="yes"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
+                  <label for="insightsiot">Internet of Things</label>
+                </li>
+              </ul>
+
+            <div class='mktoFormCol'>
+              <label class="off-left mktoLabel" for='Email'>Your email</label>
+              <input type="text" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required>
+            </div>
+
+            <div class="mktField mktLblRight">
+              <span class="mktInput mktLblRight">
+                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" tabindex="9" type="checkbox" />
+                <label for="" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+              </span>
+            </div>
+
+            <div>
+              <span style="display:none;"><input type="text" name="_marketo_comments" value=""></span>
+              <span class='mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
+              <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+              <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+              <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
+              <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+              <input type="hidden" name="ret" value="<?php $theurl = rtrim(get_permalink(),'/'); echo $theurl; ?>?digest=true" />
+              <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+              <input type="hidden" name="kw" value=""/>
+              <input type="hidden" name="cr" value=""/>
+              <input type="hidden" name="searchstr" value=""/>
+              <input type="hidden" name="_mkt_disp" value="return"/>
+              <input type="hidden" name="_mkt_trk" value=""/>
+            </div>
+          </form>
+        </div>
+        <script language="JavaScript" src="https://app.marketo.com/js/public/jquery-latest.min.js" type="text/javascript"></script>
+      </div>
+    </div>
   </div>
 </div>
 <div class="p-strip--light is-shallow">

--- a/templates/post.html
+++ b/templates/post.html
@@ -111,20 +111,20 @@
             <ul class="p-list">
               <li class="p-list__item">
               <div>
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="yes" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
                 <label for="insightscloudserver">Cloud and server</label>
               </div>
               </li>
               <li class="p-list__item">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="yes"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
                 <label for="insightsdesktop">Desktop</label>
               </li>
               <li class="p-list__item">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="yes"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
                 <label for="insightsiot">Internet of Things</label>
               </li>
               <li class="p-list__item">
-                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="yes" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
                   <label for="insightstutorials">Tutorials</label>
               </li>
             </ul>
@@ -136,8 +136,8 @@
 
           <div class="mktField mktLblRight">
             <span class="mktInput mktLblRight">
-              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" tabindex="9" type="checkbox" />
-              <label for="" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" tabindex="9" type="checkbox" />
+              <label for="canonicalUpdatesOptIn" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
             </span>
           </div>
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,6 +1,18 @@
 {% extends "layout.html" %}
 
 {% block body %}
+{% if request.args.get('newsletter') == 'true' %}
+<div class="p-strip--light  is-shallow">
+  <div class="row">
+    <div class="p-notification--positive">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Success:</span>Thank you for subscribing! You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.
+      </p>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="p-strip--light  is-shallow">
   <div class="row">
     <div class="col-10">
@@ -132,7 +144,7 @@
             <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
             <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
             <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="{{request.host}}{{request.path}}?digest=true" />
+            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?digest=true" />
             <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
             <input name="kw" value="" type="hidden">
             <input name="cr" value="" type="hidden">

--- a/templates/post.html
+++ b/templates/post.html
@@ -6,7 +6,7 @@
   <div class="row">
     <div class="p-notification--positive">
       <p class="p-notification__response">
-        <span class="p-notification__status">Success:</span>Thank you for subscribing! You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.
+        <span class="p-notification__status">Success:</span> Thank you for subscribing! You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.
       </p>
     </div>
   </div>
@@ -107,10 +107,8 @@
           <p>Choose the topics you're interested in</p>
             <ul class="p-list">
               <li class="p-list__item">
-              <div>
                 <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
                 <label for="insightscloudserver">Cloud and server</label>
-              </div>
               </li>
               <li class="p-list__item">
                 <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
@@ -144,7 +142,7 @@
             <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
             <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
             <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?digest=true" />
+            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
             <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
             <input name="kw" value="" type="hidden">
             <input name="cr" value="" type="hidden">

--- a/templates/post.html
+++ b/templates/post.html
@@ -131,7 +131,7 @@
 
           <div class="mktField mktLblRight">
             <span class="mktInput mktLblRight">
-              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" tabindex="9" type="checkbox" />
+              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
               <label for="canonicalUpdatesOptIn" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
             </span>
           </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -88,80 +88,77 @@
 
     <div class="row">
       <div class="col-8">
-        <div class="p-card">
-          <script>
-          function fieldValidate(field) {
-            /* call Mkto.setError(field, message) and return false to mark a field value invalid */
-            /* return 'skip' to bypass the built-in validations */
-            return true;
-          }
-          function getRequiredFieldMessage(domElement, label) {
-            return "This field is required";
-          }
-          function getTelephoneInvalidMessage(domElement, label) {
-            return "Please enter a valid telephone number";
-          }
-          function getEmailInvalidMessage(domElement, label) {
-            return "Please enter a valid email address";
-          }
-          </script>
-          {% if digest == 'true' %}<h1>yeah boy</h1>{% endif %}
-          {{ digest }}
-          <form class='p-form mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
-            <h2>Sign up for email updates</h2>
-            <p>Choose the topics you're interested in</p>
-              <ul class="p-list">
-                <li class="p-list__item">
-                <div>
-                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="yes" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
-                  <label for="insightscloudserver">Cloud and server</label>
-                </div>
-                </li>
-                <li class="p-list__item">
-                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="yes"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
-                  <label for="insightsdesktop">Desktop</label>
-                </li>
-                <li class="p-list__item">
-                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="yes"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
-                  <label for="insightsiot">Internet of Things</label>
-                </li>
-                <li class="p-list__item">
-                    <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="yes" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
-                    <label for="insightstutorials">Tutorials</label>
-                </li>
-              </ul>
+        <script>
+        function fieldValidate(field) {
+          /* call Mkto.setError(field, message) and return false to mark a field value invalid */
+          /* return 'skip' to bypass the built-in validations */
+          return true;
+        }
+        function getRequiredFieldMessage(domElement, label) {
+          return "This field is required";
+        }
+        function getTelephoneInvalidMessage(domElement, label) {
+          return "Please enter a valid telephone number";
+        }
+        function getEmailInvalidMessage(domElement, label) {
+          return "Please enter a valid email address";
+        }
+        </script>
 
-            <div class='mktoFormCol'>
-              <label class="off-left mktoLabel" for='Email'>Your email</label>
-              <input type="text" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required>
-            </div>
+        <form class='p-form mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
+          <h2>Sign up for email updates</h2>
+          <p>Choose the topics you're interested in</p>
+            <ul class="p-list">
+              <li class="p-list__item">
+              <div>
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="yes" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
+                <label for="insightscloudserver">Cloud and server</label>
+              </div>
+              </li>
+              <li class="p-list__item">
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="yes"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
+                <label for="insightsdesktop">Desktop</label>
+              </li>
+              <li class="p-list__item">
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="yes"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
+                <label for="insightsiot">Internet of Things</label>
+              </li>
+              <li class="p-list__item">
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="yes" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
+                  <label for="insightstutorials">Tutorials</label>
+              </li>
+            </ul>
 
-            <div class="mktField mktLblRight">
-              <span class="mktInput mktLblRight">
-                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" tabindex="9" type="checkbox" />
-                <label for="" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
-              </span>
-            </div>
+          <div class='mktoFormCol'>
+            <label class="off-left mktoLabel" for='Email'>Your email</label>
+            <input type="text" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required>
+          </div>
 
-            <div>
-              <span style="display:none;"><input type="text" name="_marketo_comments" value=""></span>
-              <span class='mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
-              <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-              <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-              <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
-              <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-              <input type="hidden" name="ret" value="http://0.0.0.0:8023{{request.path}}?digest=true" />
-              <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-              <input type="hidden" name="kw" value=""/>
-              <input type="hidden" name="cr" value=""/>
-              <input type="hidden" name="searchstr" value=""/>
-              <input type="hidden" name="_mkt_disp" value="return"/>
-              <input type="hidden" name="_mkt_trk" value=""/>
-            </div>
-          </form>
-        </div>
-        <script language="JavaScript" src="https://app.marketo.com/js/public/jquery-latest.min.js" type="text/javascript"></script>
+          <div class="mktField mktLblRight">
+            <span class="mktInput mktLblRight">
+              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" tabindex="9" type="checkbox" />
+              <label for="" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+            </span>
+          </div>
+
+          <div>
+            <span style="display:none;"><input type="text" name="_marketo_comments" value=""></span>
+            <span class='mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
+            <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+            <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+            <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
+            <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+            <input type="hidden" name="ret" value="http://insights.ubuntu.com{{request.path}}?digest=true" />
+            <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+            <input type="hidden" name="kw" value=""/>
+            <input type="hidden" name="cr" value=""/>
+            <input type="hidden" name="searchstr" value=""/>
+            <input type="hidden" name="_mkt_disp" value="return"/>
+            <input type="hidden" name="_mkt_trk" value=""/>
+          </div>
+        </form>
       </div>
+      <script language="JavaScript" src="https://app.marketo.com/js/public/jquery-latest.min.js" type="text/javascript"></script>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Add marketo newsletter sign up form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Navigate to an article, note that the 'interested in' category will be already selected based on article tags Fill out the form, you should be redirected to the same url at insights.ubuntu.com


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2391