### PR TITLE
Updated group banners with photos

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -4,26 +4,26 @@
         "slug": "cloud-and-server",
         "description": "All you need to know about designing, building and managing your OpenStack cloud or Ubuntu Server scale-out deployment.",
         "url": "https://www.ubuntu.com/cloud",
-        "hero_url": "https://assets.ubuntu.com/v1/16adbb8d-cloud-hero-build-infographic.png"
+        "hero_url": "https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg"
     },
     {
         "name": "Internet of Things",
         "slug": "internet-of-things",
         "description": "A new, snappy, transactionally updated Ubuntu for clouds and devices.",
         "url": "https://www.ubuntu.com/things",
-        "hero_url": "https://assets.ubuntu.com/v1/b181a602-iot_edge_gateways_infographic.svg"
+        "hero_url": "https://assets.ubuntu.com/v1/ee9a6ce3-drone-iceland-unsplash.jpg"
     },
     {
         "name": "Desktop",
         "slug": "desktop",
         "description": "All you need to know about the fast, free and user-friendly Ubuntu desktop operating system.",
         "url": "https://www.ubuntu.com/desktop",
-        "hero_url": "https://assets.ubuntu.com/v1/cf0a823f-image-tenders-with-ubuntu.svg"
+        "hero_url": "https://assets.ubuntu.com/v1/bf5e5af8-desktop-overview-hero.jpg"
     },
     {
         "name": "Press Centre",
         "slug": "canonical-announcements",
         "description": "Journalists and analysts seeking information should email pr@canonical.com",
-        "hero_url": "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
+        "hero_url": "https://assets.ubuntu.com/v1/f7fc5efe-image-partners.jpg"
     }
 ]

--- a/templates/group.html
+++ b/templates/group.html
@@ -12,7 +12,7 @@
           {% endif %}
         </h1>
         {% if not category %}
-          <h5 style="line-height: 1.5rem;">
+          <h5 style="line-height: 1.75rem;">
             {{ group_details.description }}
           </h5>
           {% if group_details.url %}

--- a/templates/group.html
+++ b/templates/group.html
@@ -12,18 +12,18 @@
           {% endif %}
         </h1>
         {% if not category %}
-          <p class="p-heading--five">
+          <h5 style="line-height: 1.5rem;">
             {{ group_details.description }}
-          </p>
+          </h5>
           {% if group_details.url %}
           <p>
             <a class="p-link--external" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
           </p>
           {% endif %}
         {% else %}
-          <p class="p-heading--four">
+          <h4>
             {{ category.name }}
-          </p>
+          </h4>
         {% endif %}
       </div>
       <div id="rtp-banner" class="rtp-banner"></div>

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,9 +1,9 @@
 {% extends "layout.html" %}
 {% block body %}
 
-  <div class="p-strip--light is-shallow is-bordered" style="overflow: hidden;">
+  <div class="p-strip--image  is-dark" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
     <div class="row u-equal-height u-vertically-center">
-      <div class="col-6">
+      <div class="col-6 p-card--overlay">
         <h1 class="p-heading--one">
           {% if request.path.startswith("/press-centre/") %}
             Press centre
@@ -25,11 +25,6 @@
             {{ category.name }}
           </p>
         {% endif %}
-      </div>
-      <div class="col-5 prefix-1">
-        <img src="{{ group_details.hero_url }}"
-        class="group-image u-hidden--small"
-        alt="" />
       </div>
       <div id="rtp-banner" class="rtp-banner"></div>
     </div>


### PR DESCRIPTION
## Done

- Updated group banners with photos

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - [cloud and server](http://0.0.0.0:8023/cloud-and-server/)
    - [iot](http://0.0.0.0:8023/internet-of-things/)
    - [desktop](http://0.0.0.0:8023/desktop/)
    - [press centre](http://0.0.0.0:8023/press-centre/)

## Issue / Card

Fixes #72

## Screenshots

### cloud and server
![image](https://user-images.githubusercontent.com/441217/34641753-b7e2e34a-f300-11e7-92c9-13803e93cfaa.png)
### iot
![image](https://user-images.githubusercontent.com/441217/34641755-c5c3bf52-f300-11e7-9a04-4361b35ac21b.png)
### desktop
![image](https://user-images.githubusercontent.com/441217/34641760-d70ce888-f300-11e7-98c9-5269ce00eb1a.png)
### press centre
![image](https://user-images.githubusercontent.com/441217/34641777-10f6ffc0-f301-11e7-8c8c-db67e190f76e.png)

