### PR TITLE
Replace [&hellip;] with &hellip; for post excerpts

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import json
 import humanize
 import requests
 import requests_cache
+import re
 from dateutil import parser
 from flask import url_for
 from flask import request
@@ -251,6 +252,8 @@ def _normalise_user(user):
 
 def _normalise_posts(posts):
     for post in posts:
+        if post['excerpt']['rendered']:
+            post['excerpt']['rendered'] = re.sub( r"\[\&hellip;\]", "&hellip;", post['excerpt']['rendered'] )
         post = _normalise_post(post)
     return posts
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import humanize
 import requests
 import requests_cache
 import re
+import textwrap
 from dateutil import parser
 from flask import url_for
 from flask import request
@@ -253,7 +254,9 @@ def _normalise_user(user):
 def _normalise_posts(posts):
     for post in posts:
         if post['excerpt']['rendered']:
+            post['excerpt']['rendered'] = textwrap.shorten(post['excerpt']['rendered'], width=250, placeholder="&hellip;")
             post['excerpt']['rendered'] = re.sub( r"\[\&hellip;\]", "&hellip;", post['excerpt']['rendered'] )
+            post['excerpt']['rendered'] = re.sub( r"h\d>", "p>", post['excerpt']['rendered'] )
         post = _normalise_post(post)
     return posts
 

--- a/data/topics.json
+++ b/data/topics.json
@@ -2,8 +2,8 @@
     {
         "name": "Design",
         "slug": "design",
-        "subtitle": "Branding and Web Development",
-        "description": "Learn about the Design team and what they work on, including Ubuntu and Canonical branding, Vanilla and product photography.",
+        "subtitle": "Branding and web development",
+        "description": "All the latest news on the design team at Canonical.",
         "url": "https://design.ubuntu.com",
         "logo_url": "https://assets.ubuntu.com/v1/70041419-vanilla-framework.png",
         "hero_url": "https://assets.ubuntu.com/v1/78b7c44a-hero-dots.png"
@@ -12,7 +12,7 @@
         "name": "Juju",
         "slug": "juju",
         "subtitle": "Operate big software at scale on any cloud",
-        "description": "Exploring Juju and JAAS – open source application modelling tools used to deploy, configure, scale and operate your software on public and private clouds.",
+        "description": "All the latest news on Juju – the open source application modelling tool for public and private clouds.",
         "url": "https://jujucharms.com",
         "logo_url": "https://assets.ubuntu.com/v1/31c507a5-image-juju.svg",
         "hero_url": "https://assets.ubuntu.com/v1/e8b86f15-Juju-Visual-Screen.png?w=576"
@@ -20,8 +20,8 @@
     {
         "name": "MAAS",
         "slug": "maas",
-        "subtitle": "Machine-as-a-Service",
-        "description": "All you need to know about MAAS – the smartest way to manage bare metal. Big data, private cloud, PAAS and HPC all thrive on MAAS.",
+        "subtitle": "Metal as a Service",
+        "description": "All the latest news on MAAS – the smartest way to manage bare metal.",
         "url": "https://maas.io",
         "logo_url": "https://assets.ubuntu.com/v1/5f3d3c45-maas-logo-cropped.svg",
         "hero_url": "https://assets.ubuntu.com/v1/e6c6b98f-Maas-Visual-Screen.png?w=576"
@@ -29,8 +29,8 @@
     {
         "name": "Snappy",
         "slug": "snappy",
-        "subtitle": "A ‘snap’ is a universal Linux package",
-        "description": "News from the Snappy team – articles on application architecture, prototyping, packaging paradigms and more.",
+        "subtitle": "Package any app for any Linux platform and deliver updates directly",
+        "description": "All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.",
         "url": "https://snapcraft.io",
         "logo_url": "https://assets.ubuntu.com/v1/3075aa19-snappy-icon.svg",
         "hero_url": "https://assets.ubuntu.com/v1/a91f36a8-Snapcraft-Visual-Screen.png?w=576"

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
           <h3 class="p-media-object__title" itemprop="name">
             <a href="{{ webinar.link | safe }}">{{ webinar.title | safe }}</a>
           </h3>
-          <p class="p-media-object__content">{{ webinar.summary | safe }}</p>
+          <p class="p-media-object__content">{{ webinar.summary | truncate (250, False, '&hellip;') | safe }}</p>
           <ul class="p-media-object__meta-list">
             <li class="p-media-object__meta-list-item">
               Topic: {{ webinar.category | safe }}


### PR DESCRIPTION

## Done

- Replace [&hellip;] with &hellip; for post excerpts
- Shorten excerpts to 250 characters for both posts and webinars (on the homepage)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [homepage](http://0.0.0.0:8023/)
- see that excerpts that run on end with ‘…’

## Issue / Card

Fixes #69

  