### PR TITLE
Added error route handling and error pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -448,3 +448,15 @@ def redirect_wordpress_login():
         path = '?'.join([path, urllib.parse.urlencode(flask.request.args)])
 
     return flask.redirect(INSIGHTS_URL + path)
+
+@app.errorhandler(404)
+def page_not_found(e):
+    return flask.render_template('404.html'), 404
+
+@app.errorhandler(410)
+def page_not_found(e):
+    return flask.render_template('410.html'), 410
+
+@app.errorhandler(500)
+def page_not_found(e):
+    return flask.render_template('500.html'), 500

--- a/templates/410.html
+++ b/templates/410.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}404 - page not found error{% endblock %}
+{% block title %}410 - page deleted{% endblock %}
 {% block body %}
 <div class="p-strip is-deep">
   <div class="row">
@@ -9,8 +9,8 @@
       </div>
       <div class="col-6 u-vertically-center">
         <div>
-          <h1>404: Page not found</h1>
-          <p class="p-heading--four">Sorry, we couldn&rsquo;t find that page.</p>
+          <h1>410: Page deleted</h1>
+          <p class="p-heading--four">{{ message | default:"This page has been removed" }}</p>
         </div>
       </div>
     </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}404 - page not found error{% endblock %}
+{% block title %}500 - server error{% endblock %}
 {% block body %}
 <div class="p-strip is-deep">
   <div class="row">
@@ -9,8 +9,8 @@
       </div>
       <div class="col-6 u-vertically-center">
         <div>
-          <h1>404: Page not found</h1>
-          <p class="p-heading--four">Sorry, we couldn&rsquo;t find that page.</p>
+          <h1>500: Server error</h1>
+          <p class="p-heading--four">Something&rsquo;s gone wrong, try reloading.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added error route handling and error pages for 404, 410, 500 pages, like ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a random url](http://0.0.0.0:8023/askldfk/)
- not sure how to test the 410 or 500 page

## Issue / Card

Fixes #75

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34648386-9da033e4-f390-11e7-84af-d2a881b0899f.png)
