### PR TITLE
Improved author page’s recently posted section

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -2,7 +2,7 @@
 {% block body %}
 <div class="p-strip">
   <div class="row">
-    <div class="col-10">
+    <div class="col-8">
       <div class="p-media-object">
         <img src="{{ author.avatar_urls['96'] }}" class="p-media-object__image">
         <div class="p-media-object__details">
@@ -21,9 +21,9 @@
   </div>
 </div>
 
-<div class="p-strip u-no-padding--top">
+<div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-8 prefix-1">
       <h3 class="p-heading--five">Recently posted by {{ author.name }}</h3>
       <ul class="p-list--divided">
       {% for post in author.recent_posts %}


### PR DESCRIPTION
## Done

- Improved author page’s recently posted section by putting it in a p-strip--light strip and aligning it with the author bio

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [dustin’s page](http://0.0.0.0:8023/author/kirkland/) or [Canonical’s page](http://0.0.0.0:8023/author/canonical/)

## Issue / Card

Fixes #76

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34648620-77251ea6-f394-11e7-998a-a973efde834f.png)
