### PR TITLE
Added post date to posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ import datetime
 import urllib
 import flask
 import json
-import humanize
 import requests
 import requests_cache
 import re
@@ -265,9 +264,7 @@ def _normalise_post(post):
     link = post['link']
     path = urlsplit(link).path
     post['relative_link'] = path
-    post['formatted_date'] = humanize.naturaldate(
-        parser.parse(post['date'])
-    )
+    post['formatted_date'] = datetime.datetime.strftime(parser.parse(post['date']), "%d %B %Y").lstrip("0").replace(" 0", " ")
     post = _embed_post_data(post)
     return post
 
@@ -295,9 +292,7 @@ def _normalise_post(post):
     link = post['link']
     path = urlsplit(link).path
     post['relative_link'] = path
-    post['formatted_date'] = humanize.naturaldate(
-        parser.parse(post['date'])
-    )
+    post['formatted_date'] = datetime.datetime.strftime(parser.parse(post['date']), "%d %B %Y").lstrip("0").replace(" 0", " ")
     post = _embed_post_data(post)
     return post
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -16,7 +16,7 @@
 <div class="p-strip--light  is-shallow">
   <div class="row">
     <div class="col-10">
-      <p><img src="{{ post.author.avatar_urls["48"] }}" alt="{{ post.author.name }}"> by <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a></p>
+      <p><img src="{{ post.author.avatar_urls["48"] }}" alt="{{ post.author.name }}"> by <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on  {{ post.formatted_date }}</p>
     </div>
   </div>
   <div class="row">
@@ -174,7 +174,7 @@
         </a>
       </h4>
       <p>
-        {{ post.excerpt.rendered | safe }}
+        {{ related.excerpt.rendered | truncate (250, False, '&hellip;') | safe }}
       </p>
     </div>
     {% endif %}


### PR DESCRIPTION
## Done

- Added post date to posts
- Truncated related posts excerpts
- Fixed related posts to use correct excerpt

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any post](http://0.0.0.0:8023/2017/12/20/canonical-welcome-spotify-as-a-snap-for-linux-users/)
    - see that there is a date
    - see that the related posts are truncated at 250 chars
    - see that the replate posts excerpts are fixed

## Issue / Card

Fixes #17

Signed-off-by: Peter Mahnke <peter@transitionelement.com>

## Screenshots
### date
![image](https://user-images.githubusercontent.com/441217/34650718-798101a0-f3bd-11e7-963b-f446815de703.png)

### related posts
![image](https://user-images.githubusercontent.com/441217/34650713-6c5e8af6-f3bd-11e7-8e2c-856be180a678.png)
