### PR TITLE
Remove whitebackground from footer

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -133,3 +133,8 @@ pre {
     height: 320px;
   }
 }
+
+/// XXX remove whitespace under footer
+.p-footer {
+  padding-bottom: 2.5rem;
+}


### PR DESCRIPTION
## Done

- Remove white background from below the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any page](http://0.0.0.0:8023/2017/12/20/canonical-welcome-spotify-as-a-snap-for-linux-users/)
- see that there is no whitespace below the footer

## Issue / Card

Fixes #8 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34650852-976ce768-f3bf-11e7-83f9-80e22abb41e1.png)
