### PR TITLE
Return 404 for a bad /tag/ page

### DIFF
--- a/app.py
+++ b/app.py
@@ -409,14 +409,9 @@ def tag_index(slug):
             'tag.html', posts=posts, tag=tag, **metadata
         )
     else:
-        tag = {
-            "id": -1,
-            "name": slug
-        }
-
         return flask.render_template(
-            'tag.html', posts=[], tag=tag, **{}
-        ), 404
+            '404.html'
+        )
 
 
 @app.route(


### PR DESCRIPTION
## Done

- Return 404 for a bad /tag/ page%

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [tag that doesn’t exist](http://0.0.0.0:8023/tag/bullshit/)
- See that it returns a 404

## Issue / Card

Fixes #23

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34650898-5e9b7b9c-f3c0-11e7-9072-6002aab74cba.png)
