### PR TITLE
Moved newsletter to right rail, added product cards, banner background

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -133,3 +133,11 @@ pre {
     height: 320px;
   }
 }
+
+// XXX from ubuntu.com
+.has-background {
+  background-color: #f7f7f7;
+  background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);
+  background-position: center top;
+  background-repeat: repeat-y;
+}

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -1,0 +1,62 @@
+  <div class="p-card">
+    <header>
+      <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
+      <h3 class="p-card--title p-heading--four">Sign up for email updates</h3>
+    </header>
+      <p class="p-card--content">Choose the topics you're interested in</p>
+        <ul class="p-list p-card--content">
+          <li class="p-list__item u-no-margin--top">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
+            <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label class="u-no-margin--top">
+          </li>
+          <li class="p-list__item u-no-margin--top">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
+            <label class="u-no-margin--top" for="insightsdesktop">Desktop</label class="u-no-margin--top">
+          </li>
+          <li class="p-list__item u-no-margin--top">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
+            <label class="u-no-margin--top" for="insightsiot">Internet of Things</label class="u-no-margin--top">
+          </li>
+          <li class="p-list__item u-no-margin--top">
+              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
+              <label class="u-no-margin--top" for="insightstutorials">Tutorials</label class="u-no-margin--top">
+          </li>
+        </ul>
+
+      <div class="mktFormReq mktField">
+        <label class="u-no-margin--top" for="Email" class="mktolabel class="u-no-margin--top"">Work email: <span>*</span></label class="u-no-margin--top">
+        <input required  id="Email" name="Email" maxlength="255" type="email" class="u-no-margin--top mktoField mktoEmailField  mktoRequired" />
+      </div>
+
+      <div class=" u-no-margin--topmktField mktLblRight">
+        <span class="mktInput mktLblRight">
+          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+          <label class="u-no-margin--top" for="canonicalUpdatesOptIn" class="p-form__label u-no-margin--top">I would like to receive occasional updates from Canonical by email.</label class="u-no-margin--top">&nbsp;<span class="mktFormMsg"></span>
+        </span>
+      </div>
+
+      <div class="u-no-margin--top">
+        <span class='u-no-margin--top mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
+        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+        <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
+        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+        <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
+        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+        <input name="kw" value="" type="hidden">
+        <input name="cr" value="" type="hidden">
+        <input name="searchstr" value="" type="hidden">
+        <input name="_mkt_disp" value="return" type="hidden">
+        <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+      </div>
+    </form>
+  </div>
+  <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+  <script>
+  $("#mktoForm_1212").validate({
+      errorElement: "span",
+      errorClass: "mktFormMsg mktError"
+  });
+  </script>
+</div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 {% if request.args.get('newsletter') == 'true' %}
-<div class="p-strip--light  is-shallow">
+<div class="p-strip--light is-shallow">
   <div class="row">
     <div class="p-notification--positive">
       <p class="p-notification__response">
@@ -13,7 +13,7 @@
 </div>
 {% endif %}
 
-<div class="p-strip--light  is-shallow">
+<div class="p-strip--light has-background is-shallow">
   <div class="row">
     <div class="col-10">
       <p><img src="{{ post.author.avatar_urls["48"] }}" alt="{{ post.author.name }}"> by <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a></p>
@@ -80,81 +80,9 @@
       {{ post.content.rendered | safe }}
     </div>
     <div class="col-4">
-      <div class="p-card" {% if post.topics[0] %} id="rtp-{{ post.topics[0].slug }}" {% endif %}>
-        <h3>
-          <a href="http://www.ubuntu.com/cloud" class="p-link--external">
-            Ubuntu cloud
-          </a>
-        </h3>
-        <p>
-          Ubuntu offers all the training, software infrastructure, tools,
-          services and support you need for your public and private clouds.
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="p-strip is-shallow">
-    <div class="row">
-      <div class="col-8">
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
-          <h2>Sign up for email updates</h2>
-          <p>Choose the topics you're interested in</p>
-            <ul class="p-list">
-              <li class="p-list__item">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" {% if post.topics[0].slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
-                <label for="insightscloudserver">Cloud and server</label>
-              </li>
-              <li class="p-list__item">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop"{% if post.topics[0].slug == 'desktop' %} checked="checked"{% endif %} />
-                <label for="insightsdesktop">Desktop</label>
-              </li>
-              <li class="p-list__item">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things"{% if post.topics[0].slug == 'internet-of-things' %} checked="checked"{% endif %} />
-                <label for="insightsiot">Internet of Things</label>
-              </li>
-              <li class="p-list__item">
-                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" {% if post.topics[0].slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
-                  <label for="insightstutorials">Tutorials</label>
-              </li>
-            </ul>
-
-          <div class='mktFormReq mktField'>
-            <label for="Email" class="mktoLabel">Work email: <span>*</span></label>
-            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
-          </div>
-
-          <div class="mktField mktLblRight">
-            <span class="mktInput mktLblRight">
-              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-              <label for="canonicalUpdatesOptIn" class="p-form__label">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
-            </span>
-          </div>
-
-          <div>
-            <span class='mktoButtonWrap'><button type='submit' class='mktoButton'>Subscribe now</button></span>
-            <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-            <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-            <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
-            <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
-            <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-            <input name="kw" value="" type="hidden">
-            <input name="cr" value="" type="hidden">
-            <input name="searchstr" value="" type="hidden">
-            <input name="_mkt_disp" value="return" type="hidden">
-            <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-          </div>
-        </form>
-      </div>
-      <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-      <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-      <script>
-      $("#mktoForm_1212").validate({
-          errorElement: "span",
-          errorClass: "mktFormMsg mktError"
-      });
-      </script>
+      {# right rail #}
+      {% include 'product-cards.html' %}
+      {% include 'newsletter-form.html' %}
     </div>
   </div>
 </div>

--- a/templates/product-cards.html
+++ b/templates/product-cards.html
@@ -1,0 +1,68 @@
+{% if post.topics[0].slug == "cloud" %}
+<div class="p-card" id="rtp-cloud">
+  <h3>
+    <a href="http://www.ubuntu.com/cloud" class="p-link--external">
+      Ubuntu cloud
+    </a>
+  </h3>
+  <p>
+    Ubuntu offers all the training, software infrastructure, tools,
+    services and support you need for your public and private clouds.
+  </p>
+</div>
+{% elif post.topics[0].slug == "internet-of-things" %}
+<div class="p-card" id="rtp-iot">
+  <h3>
+    <a href="http://www.ubuntu.com/internet-of-things" class="p-link--external">
+      Internet of Things
+    </a>
+  </h3>
+  <p>
+    From home control to drones, robots and industrial systems, Ubuntu Core and Snaps provide robust security, app stores and reliable updates for all your IoT devices.
+  </p>
+</div>
+{% elif post.topics[0].slug == "support" %}
+<div class="p-card" id="rtp-support">
+  <h3>
+    <a href="http://www.ubuntu.com/support" class="p-link--external">
+      Ubuntu Advantage support
+    </a>
+  </h3>
+  <p>
+    If you are running Ubuntu in your organisation, you should talk to us about getting Ubuntu Advantage support with Landscape management tools.
+  </p>
+</div>
+{% elif post.topics[0].slug == "desktop" %}
+<div class="p-card" id="rtp-desktop">
+  <h3>
+    <a href="http://www.ubuntu.com/desktop" class="p-link--external">
+      Ubuntu desktop
+    </a>
+  </h3>
+  <p>
+    Learn how the Ubuntu desktop operating system powers millions of PCs and laptops around the world.
+  </p>
+</div>
+{% elif post.topics[0].slug == "server" %}
+<div class="p-card" id="rtp-server">
+  <h3>
+    <a href="http://www.ubuntu.com/server" class="p-link--external">
+      Ubuntu Server
+    </a>
+  </h3>
+  <p>
+    The leading platform for scale-out computing, Ubuntu Server delivers the best value scale-out performance available.
+  </p>
+</div>
+{% else %}
+<div class="p-card" id="rtp-contact-us">
+  <h3>
+    <a href="https://www.ubuntu.com/about/contact-us/form" class="p-link--external">
+      Talk to us today
+    </a>
+  </h3>
+  <p>
+    Interested in running Ubuntu Desktop in your organisation?
+  </p>
+</div>
+{% endif %}


### PR DESCRIPTION
## Done

- Moved newsletter to right rail
- Added product cards
- Added banner background to posts

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any post](http://0.0.0.0:8023/2017/12/20/machine-reservation-and-multi-tenancy-in-maas/)
- See that the correct product card is displayed
- See that the newsletter form is in place

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34673989-16dbc19c-f47c-11e7-81f3-425fa98e2d10.png)
