### PR TITLE
Remove social links from the authors pages

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -9,11 +9,6 @@
           <h1 class="p-media-object__title">
             {{ author.name }}
           </h1>
-          <ul class="p-media-object__meta-list">
-            <li class="p-media-object__meta-list-item">
-              <a href="{{ author.url }}">Google+</a>
-            </li>
-          </ul>
           <p class="p-media-object__content">{{ author.description }}</p>
         </div>
       </div>


### PR DESCRIPTION
## Done
Removed the social links from the author page as it is not available via the api feed.

## QA
- Pull branch
- Run `./run`
- Check out a few author pages
- Check there are no links under the author bio

## Screenshot
![screenshot-2018-1-12 ubuntu insights](https://user-images.githubusercontent.com/1413534/34854165-dc1a2614-f72f-11e7-86f5-28e72125f3b5.png)

Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/6