### PR TITLE
Changed posts to cards with topic and resource type info

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,6 +99,15 @@ class RegexConverter(BaseConverter):
 
 app.url_map.converters['regex'] = RegexConverter
 
+def _get_categories():
+    api_url = '{api_url}/categories'.format(
+        api_url=API_URL,
+        slug=slugs,
+    )
+    response = _get_from_cache(api_url)
+    categories = json.loads(response.text)
+    return categories
+
 def _get_categories_by_slug(slugs=[]):
     if slugs:
         if isinstance(slugs, list):
@@ -125,7 +134,7 @@ def _get_groups_by_slug(slugs=[]):
 
 
 def _get_posts(groups=[], categories=[], tags=[], page=None):
-    api_url = '{api_url}/posts?_embed&page={page}'.format(
+    api_url = '{api_url}/posts?_embed&per_page=12&page={page}'.format(
         api_url=API_URL,
         page=str(page or 1),
     )
@@ -158,7 +167,7 @@ def _get_posts(groups=[], categories=[], tags=[], page=None):
 
 
 def _get_related_posts(post):
-    api_url = '{api_url}/tags?embed&post={post_id}'.format(
+    api_url = '{api_url}/tags?embed&per_page=3&post={post_id}'.format(
         api_url=API_URL,
         post_id=post['id'],
     )
@@ -211,6 +220,16 @@ def _get_topic_details_from_post(post_id):
     return topics
 
 
+def _get_group_details_from_post(post_id):
+    api_url = '{api_url}/group?post={post_id}'.format(
+        api_url=API_URL,
+        post_id=post_id,
+    )
+    response = _get_from_cache(api_url)
+    groups = json.loads(response.text)
+    return groups
+
+
 def _get_featured_post(groups=[], categories=[], per_page=1):
     api_url = '{api_url}/posts?_embed&sticky=true&per_page={per_page}'.format(
         api_url=API_URL,
@@ -239,6 +258,7 @@ def _embed_post_data(post):
     post['category'] = _get_category_from_post(post['id'])
     post['tags'] = _get_tag_details_from_post(post['id'])
     post['topics'] = _get_topic_details_from_post(post['id'])
+    post['groups'] = _get_group_details_from_post(post['id'])
     return post
 
 
@@ -253,9 +273,14 @@ def _normalise_user(user):
 def _normalise_posts(posts):
     for post in posts:
         if post['excerpt']['rendered']:
-            post['excerpt']['rendered'] = textwrap.shorten(post['excerpt']['rendered'], width=250, placeholder="&hellip;")
-            post['excerpt']['rendered'] = re.sub( r"\[\&hellip;\]", "&hellip;", post['excerpt']['rendered'] )
+            # replace headings (e.g. h1) to paragraphs
             post['excerpt']['rendered'] = re.sub( r"h\d>", "p>", post['excerpt']['rendered'] )
+            # remove images
+            post['excerpt']['rendered'] = re.sub( r"<img(.[^>]*)?", "", post['excerpt']['rendered'] )
+            # shorten to 250 chars, on a wordbreak and with a ...
+            post['excerpt']['rendered'] = textwrap.shorten(post['excerpt']['rendered'], width=250, placeholder="&hellip;")
+            # if there is a [...] replace with ...
+            post['excerpt']['rendered'] = re.sub( r"\[\&hellip;\]", "&hellip;", post['excerpt']['rendered'] )
         post = _normalise_post(post)
     return posts
 
@@ -288,13 +313,6 @@ def _load_rss_feed(url, limit=5):
     feed_content = get_rss_feed_content(url, limit=limit)
     return feed_content
 
-def _normalise_post(post):
-    link = post['link']
-    path = urlsplit(link).path
-    post['relative_link'] = path
-    post['formatted_date'] = datetime.datetime.strftime(parser.parse(post['date']), "%d %B %Y").lstrip("0").replace(" 0", " ")
-    post = _embed_post_data(post)
-    return post
 
 @app.route('/')
 @app.route('/<group>/')

--- a/data/topics.json
+++ b/data/topics.json
@@ -11,6 +11,7 @@
     {
         "name": "Juju",
         "slug": "juju",
+        "strip_css": "p-strip--accent is-dark",
         "subtitle": "Operate big software at scale on any cloud",
         "description": "All the latest news on Juju – the open source application modelling tool for public and private clouds.",
         "url": "https://jujucharms.com",
@@ -20,6 +21,7 @@
     {
         "name": "MAAS",
         "slug": "maas",
+        "strip_css": "p-strip--accent is-dark",
         "subtitle": "Metal as a Service",
         "description": "All the latest news on MAAS – the smartest way to manage bare metal.",
         "url": "https://maas.io",
@@ -30,7 +32,7 @@
         "name": "Snappy",
         "slug": "snappy",
         "strip_css": "p-strip--accent is-dark",
-        "subtitle": "Package any app for any Linux platform and deliver updates directly",
+        "subtitle": "Package any app for any Linux platform",
         "description": "All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.",
         "url": "https://snapcraft.io",
         "logo_url": "https://assets.ubuntu.com/v1/a861450c-snapcraft-logo.svg",

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -1,0 +1,44 @@
+@mixin insights-p-card {
+
+  %p-card__header {
+    color: $color-x-light;
+    margin: -21px -21px 21px -21px;
+    padding: 1rem;
+  }
+
+  .p-card__header--desktop {
+    @extend %p-card__header;
+    background-color: #749F8D;
+  }
+
+  .p-card__header--canonical-announcements {
+    @extend %p-card__header;
+    background-color: #FF8936 ;
+  }
+
+  .p-card__header--cloud-and-server {
+    @extend %p-card__header;
+    background-color: #48929B;
+  }
+
+  .p-card__header--internet-of-things {
+    @extend %p-card__header;
+    background-color: #A87CA0;
+  }
+
+  .p-card__header--phone-and-tablet {
+    @extend %p-card__header;
+    background-color: #8DB255;
+  }
+
+  .p-card__footer {
+    border-top: 1px dotted #cdcdcd;
+    height: $sp-x-large;
+    margin-top: $sp-x-large;
+    padding-top: $sp-xx-small;
+
+    > p {
+      color: $color-mid-dark;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,10 +6,12 @@ $breakpoint-navigation-threshold: 990px;
 @import 'pattern_social-share';
 @import 'pattern_rtp';
 @import 'pattern_form';
+@import 'pattern_card';
 
 @include insights-p-social-share;
 @include insights-p-rtp;
 @include insights-p-form;
+@include insights-p-card;
 
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block body %}
 
-  <div class="p-strip--image  is-dark" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
+  <section class="p-strip--image  is-dark" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6 p-card--overlay">
         <h1 class="p-heading--one">
@@ -11,24 +11,76 @@
             {{ group_details.name }}
           {% endif %}
         </h1>
-        {% if not category %}
-          <h5 style="line-height: 1.75rem;">
-            {{ group_details.description }}
-          </h5>
-          {% if group_details.url %}
-          <p>
-            <a class="p-link--external" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
-          </p>
-          {% endif %}
-        {% else %}
-          <h4>
-            {{ category.name }}
-          </h4>
+        <h5 style="line-height: 1.75rem;">
+          {{ group_details.description }}
+        </h5>
+        {% if group_details.url %}
+        <p>
+          <a class="p-link--external" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
+        </p>
         {% endif %}
       </div>
       <div id="rtp-banner" class="rtp-banner"></div>
     </div>
-  </div>
+  </section>
+
+  <section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+    <nav class="p-tabs col-12">
+      <div class="row">
+        <ul class="p-tabs__list" role="tablist">
+          {% if group_details.slug == 'cloud-and-server' %}
+          <li class="p-tabs__item" role="presentation">
+            <a href="/cloud-and-server/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/cloud-and-server/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/cloud-and-server/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/cloud-and-server/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/cloud-and-server/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
+          </li>
+          {% elif group_details.slug == 'internet-of-things' %}
+          <li class="p-tabs__item" role="presentation">
+            <a href="/internet-of-things/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/internet-of-things/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/internet-of-things/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/internet-of-things/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/internet-of-things/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
+          </li>
+          {% elif group_details.slug == 'desktop' %}
+          <li class="p-tabs__item" role="presentation">
+            <a href="/desktop/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/desktop/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/desktop/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/desktop/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/desktop/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
+          </li>
+          {% endif %}
+        </ul>
+      </div>
+    </nav>
+  </section>
 
   {% include "posts.html" %}
 

--- a/templates/group.html
+++ b/templates/group.html
@@ -28,53 +28,21 @@
     <nav class="p-tabs col-12">
       <div class="row">
         <ul class="p-tabs__list" role="tablist">
-          {% if group_details.slug == 'cloud-and-server' %}
+          {% if group_details.slug == 'cloud-and-server' or group_details.slug == 'internet-of-things' or group_details.slug == 'destkop' %}
           <li class="p-tabs__item" role="presentation">
-            <a href="/cloud-and-server/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
+            <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="/cloud-and-server/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
+            <a href="/{{ group_details.slug }}/articles" class="p-tabs__link"  role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="/cloud-and-server/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
+            <a href="/{{ group_details.slug }}/case-studies" class="p-tabs__link" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="/cloud-and-server/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
+            <a href="/{{ group_details.slug }}/videos" class="p-tabs__link"  role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="/cloud-and-server/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-          </li>
-          {% elif group_details.slug == 'internet-of-things' %}
-          <li class="p-tabs__item" role="presentation">
-            <a href="/internet-of-things/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/internet-of-things/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/internet-of-things/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/internet-of-things/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/internet-of-things/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-          </li>
-          {% elif group_details.slug == 'desktop' %}
-          <li class="p-tabs__item" role="presentation">
-            <a href="/desktop/all" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/desktop/articles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section2" {% if category.slug == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/desktop/case-studies" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section3" {% if category.slug == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/desktop/videos" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section4" {% if category.slug == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/desktop/webinars" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
+            <a href="/{{ group_details.slug }}/webinars" class="p-tabs__link"  role="tab" aria-controls="section5" {% if category.slug == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
           </li>
           {% endif %}
         </ul>

--- a/templates/group.html
+++ b/templates/group.html
@@ -28,7 +28,7 @@
     <nav class="p-tabs col-12">
       <div class="row">
         <ul class="p-tabs__list" role="tablist">
-          {% if group_details.slug == 'cloud-and-server' or group_details.slug == 'internet-of-things' or group_details.slug == 'destkop' %}
+          {% if group_details.slug != 'canonical-announcements' %}
           <li class="p-tabs__item" role="presentation">
             <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category.slug is not defined %} aria-selected="true"{% endif %}>All</a>
           </li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,13 +21,13 @@
 </div>
 
 {% if featured_post %}
-<div class="p-strip is-shallow is-bordered">
+<div class="p-strip--light is-shallow">
   <div class="row">
     <div class="col-8">
       <h3 class="p-heading--four">Featured article</h3>
       <h2 class="p-heading--three"><a href="{{ featured_post.relative_link }}">{{ featured_post.title.rendered | safe }}</a></h2>
       <p>By <a href="{{ featured_post.author.relative_link }}" title="More about {{ featured_post.author.name }}">{{ featured_post.author.name }}</a>, {{ featured_post.formatted_date }}</p>
-      <p class="u-no-padding--bottom">{{ featured_post.excerpt.rendered | safe }}</p>
+      <p class="u-no-padding--bottom">{{ featured_post.excerpt.rendered | striptags | urlize(30, true) }}</p>
     </div>
   </div>
 </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -174,7 +174,7 @@
         </a>
       </h4>
       <p>
-        {{ related.excerpt.rendered | truncate (250, False, '&hellip;') | safe }}
+        {{ related.excerpt.rendered | truncate (250, False, '&hellip;') | striptags | urlize(30, true) }}
       </p>
     </div>
     {% endif %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,15 +1,27 @@
 {% block posts %}
 
-{% for post in posts %}
-  <div class="p-strip is-shallow is-bordered">
-    <div class="row">
-      <div class="col-8">
-        <h2 class="p-heading--three"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
+<div class="p-strip is-bordered">
+{%- for post in posts %}
+  {% if loop.index0 % 3 == 0 %}
+  <div class="row u-equal-height u-clearfix">
+  {% endif %}
+    <div class="col-4 p-card">
+      <header class="p-card__header--{{ post.groups[0].slug }}">
+        <h5 class="p-muted-heading">{{ post.groups[0].name }}</h5>
+      </header>
+      <h2 class="p-card__title p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h2>
+      <div class="p-card__content">
         <p>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.formatted_date }}</p>
-        <p class="u-no-padding--bottom">{{ post.excerpt.rendered | safe }}</p>
+        <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
       </div>
+      <footer class="p-card__footer">
+        <p>{{ post.category | capitalize }}</p>
+      </footer>
     </div>
+  {% if loop.index0 % 3 == 2 or loop.last %}
   </div>
-{% endfor %}
+  {% endif %}
+{%- endfor %}
+</div>
 
 {% endblock %}

--- a/templates/topics.html
+++ b/templates/topics.html
@@ -10,7 +10,7 @@
             <h1 class="p-heading--one p-heading-icon__title">{{ topic.name }}</h1>
           </div>
           <h2 class="p-heading--two">{{ topic.subtitle }}</h2>
-          <p class="p-heading--five">{{ topic.description }}</p>
+          <p class="p-heading--five">{{ topic.description | safe }}</p>
         </div>
           <p>
             <a class="p-link--external" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="col-5 prefix-1">
         <img src="{{ topic.hero_url }}"
-        class="{% if topic.name == 'Design' %}design-image{% else %}card-image{% endif %} u-hidden--small u-image-position--bottom"
+        class="{% if topic.name == 'Design' %}design-image{% endif %} u-hidden--small u-image-position--bottom"
         alt="" />
       </div>
     </div>


### PR DESCRIPTION
## Done

- Changed posts to cards with topic and resource type info
- Moved to striptags filter from safe as a lot of misc html was appearing, also turned urls into 30 char long live urls
- On the homepage, made the featured post have a light background
- On group pages, got rid of the type name in the banner and added a tab of types
- On topic pages, made all, except design, have an accent background
- Filed a bug for the featured post appearing on the homepage twice #94

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any page](http://0.0.0.0:8023/)
- see that the design looks ok
- see that the content is good

