### PR TITLE
Make the drop down menus white

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -43,7 +43,7 @@ pre {
   height: $sp-x-small;
   left: 0;
   position: absolute;
-  top: -$sp-x-small;
+  top: -7px;
   width: 150px;
   z-index: 999;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -37,7 +37,7 @@ pre {
 }
 
 .p-navigation .p-navigation__nav ul li:hover ul::after {
-  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAICAYAAAD5nd/tAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QYODgYVPPJJpQAAAT9JREFUKM+dkD9IAnEUx7+/IkVxFaxoKYxIWhqKwJw0JAJ315Yac8+1tUFo6HCp34XRdRp11z+J4BzckqShPzdEQ5G/EhPO6V5Tcg3G0QcePHjvffjygB4oXAIApFMxyPlcWM7nwulU7NfMNQqXGABsZNcCCpcKtapBtapBCpcK2fXlAAAcy3vMlUxTdgEAO9ubybPiPjWFoE6nQ5ZlUfNDULl0RAdSPuncddL30+gnCgOAlngLaocyn4nG9fmFJXj9fhARAMDr82MuEcfk7LSuFQu8DTvovO1SuTxlAKCqPFO5Ov/6FIIsy/qzROOdrst6S1V5xunomo0LrT4yOh4JDg6BMXfvIdvGs/mExutLPZpYnAIAdmNUVuwBbI1NRODxePEf2u0WHu9u4ev3rTLTfKBQaNh1qp5piWCa9/gGBheo3r6AmYcAAAAASUVORK5CYII=') $sp-large bottom no-repeat;
+  background: url('https://assets.ubuntu.com/v1/b70e6370-nav-arrow-white.svg') $sp-large bottom no-repeat;
   content: '';
   display: block;
   height: $sp-x-small;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -49,7 +49,7 @@ pre {
 }
 
 .hover-menu {
-  background: $color-light;
+  background: $color-x-light;
   border: 1px solid $color-mid-light;
   border-radius: 10px;
   box-shadow: 0 2px 2px -1px $color-mid-light;


### PR DESCRIPTION
## Done
Set the background of the hover menu to white.

## QA
- Check out the demo and hover over the menu 
- The drop down menu background is white

## Details
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/95