### PR TITLE
Update the press centre blurb

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -23,7 +23,7 @@
     {
         "name": "Press Centre",
         "slug": "canonical-announcements",
-        "description": "Journalists and analysts seeking information should email pr@canonical.com",
+        "description": "The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact <a href='mailto:pr@canonical.com'>pr@canonical.com</a>",
         "hero_url": "https://assets.ubuntu.com/v1/f7fc5efe-image-partners.jpg"
     }
 ]


### PR DESCRIPTION
## Done
Update the press centre blurb with an email link

## QA
- Open the demo
- Go to the Press centre
- Check that the blurb matches: "The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact pr@canonical.com"

Fixes https://github.com/ubuntudesign/web-squad/issues/280