### PR TITLE
Add null checking for post types

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,7 +262,8 @@ def _embed_post_data(post):
     if GROUP:
         post['groups'] = _get_group_by_id(GROUP)
     else:
-        post['groups'] = _get_group_by_id(post['group'][0])
+        if post['group']:
+            post['groups'] = _get_group_by_id(post['group'][0])
     return post
 
 def _normalise_user(user):


### PR DESCRIPTION
## Done
Added null checking for `GROUPS` as posts can have none.

## QA
- Pull code
- Run `./run`
- Go to http://0.0.0.0:8023/2018/01/24/meltdown-spectre-and-ubuntu-what-you-need-to-know/
- Check the pages loads without errors

## Details
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/116