### PR TITLE
Upgrade Vanilla-framework to v1.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.6.0",
+    "vanilla-framework": "1.6.5",
     "watch-cli": "^0.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,9 +2490,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.0.tgz#34ad19d6361f716752c2a1726d6631bfbe7ce9a1"
+vanilla-framework@1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
Upgrade Vanilla dep to v1.6.5

## QA
- Pull code and run `./run`
- On the homepage scroll to the Webinars section 
- Check the images are not stretched
- Click around the site and check everything works the same

## Detail
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/102 