### PR TITLE
Align category tabs with article cards

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -171,3 +171,12 @@ pre {
     display: none !important;
   }
 }
+
+// XXX Caleb - Tabs padding fixes
+.p-tabs__list {
+  padding: 0;
+
+  @media (min-width: $breakpoint-medium) {
+    padding: 0;
+  }
+}


### PR DESCRIPTION
# Done

- Removed left and right padding from category tabs, so they align left with cards