### PR TITLE
Added suru overlay to group pages

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -23,7 +23,7 @@
     {
         "name": "Press Centre",
         "slug": "canonical-announcements",
-        "description": "The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact <a href='mailto:pr@canonical.com'>pr@canonical.com</a>",
+        "description": "The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact <a class='p-link--inverted' href='mailto:pr@canonical.com'>pr@canonical.com</a>",
         "hero_url": "https://assets.ubuntu.com/v1/f7fc5efe-image-partners.jpg"
     }
 ]

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -3,7 +3,7 @@
 }
 
 @mixin insights-p-strips-suru {
-  .suru {
+  .p-strip--suru {
     position: relative;
     overflow: hidden;
 

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -20,11 +20,15 @@
       @media only screen and (min-width: $breakpoint-medium) {
         bottom: 0;
         height: 300%;
-        left: -100%;
+        left: -95%;
         right: 0;
         -webkit-transform: rotate(300deg);
         transform: rotate(300deg);
         width: 200%;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        left: -100%;
       }
     }
   }

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -8,13 +8,17 @@
     overflow: hidden;
 
     &::after {
-      background: linear-gradient(110deg, rgba(17, 17, 17,.65) 50%, rgba(255, 255, 255,0) 50%);
+      background: rgba(17, 17, 17, 0.65);
       content: '';
       height: 100%;
       position: absolute;
       top: 0;
       width: 100%;
       z-index: 0;
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        background: linear-gradient(110deg, rgba(17, 17, 17,.65) 55%, rgba(255, 255, 255,0) 55%);
+      }
     }
   }
 

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -8,28 +8,13 @@
     overflow: hidden;
 
     &::after {
-      background: rgba(17, 17, 17, 0.65);
+      background: linear-gradient(110deg, rgba(17, 17, 17,.65) 50%, rgba(255, 255, 255,0) 50%);
       content: '';
-      display: inline-block;
       height: 100%;
       position: absolute;
       top: 0;
       width: 100%;
       z-index: 0;
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        bottom: 0;
-        height: 300%;
-        left: -95%;
-        right: 0;
-        -webkit-transform: rotate(300deg);
-        transform: rotate(300deg);
-        width: 200%;
-      }
-
-      @media only screen and (min-width: $breakpoint-large) {
-        left: -100%;
-      }
     }
   }
 

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -1,0 +1,36 @@
+@mixin insights-p-strips {
+  @include insights-p-strips-suru;
+}
+
+@mixin insights-p-strips-suru {
+  .suru {
+    position: relative;
+    overflow: hidden;
+
+    &::after {
+      background: rgba(17, 17, 17, 0.65);
+      content: '';
+      display: inline-block;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 0;
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        bottom: 0;
+        height: 300%;
+        left: -100%;
+        right: 0;
+        -webkit-transform: rotate(300deg);
+        transform: rotate(300deg);
+        width: 200%;
+      }
+    }
+  }
+
+  .p-card--suru {
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -35,6 +35,7 @@ pre {
 @media (min-width: $breakpoint-medium + 1) {
   .p-navigation__link:hover .hover-menu {
     display: block;
+    z-index: 10;
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -7,11 +7,13 @@ $breakpoint-navigation-threshold: 990px;
 @import 'pattern_rtp';
 @import 'pattern_form';
 @import 'pattern_card';
+@import 'pattern_strips';
 
 @include insights-p-social-share;
 @include insights-p-rtp;
 @include insights-p-form;
 @include insights-p-card;
+@include insights-p-strips;
 
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block body %}
 
-  <section class="p-strip--image is-dark suru" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
+  <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6 p-card--suru">
         <h1 class="p-heading--one">

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,9 +1,9 @@
 {% extends "layout.html" %}
 {% block body %}
 
-  <section class="p-strip--image  is-dark" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
+  <section class="p-strip--image is-dark suru" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
     <div class="row u-equal-height u-vertically-center">
-      <div class="col-6 p-card--overlay">
+      <div class="col-6 p-card--suru">
         <h1 class="p-heading--one">
           {% if request.path.startswith("/press-centre/") %}
             Press centre
@@ -16,7 +16,7 @@
         </h5>
         {% if group_details.url %}
         <p>
-          <a class="p-link--external" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
+          <a class="p-link--external p-link--inverted" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
         </p>
         {% endif %}
       </div>


### PR DESCRIPTION
## Done

- Added suru overlay to group pages
- Small loses the overlay shape

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [group page](http://0.0.0.0:8023/cloud-and-server/)

## Issue / Card

Fixes #130

Signed-off-by: Peter Mahnke <peter@transitionelement.com>