### PR TITLE
Update logos to ones that include text

### DIFF
--- a/data/topics.json
+++ b/data/topics.json
@@ -5,7 +5,7 @@
         "subtitle": "Branding and web development",
         "description": "All the latest news on the design team at Canonical.",
         "url": "https://design.ubuntu.com",
-        "logo_url": "https://assets.ubuntu.com/v1/70041419-vanilla-framework.png",
+        "logo_url": "https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg",
         "hero_url": "https://assets.ubuntu.com/v1/78b7c44a-hero-dots.png"
     },
     {
@@ -15,7 +15,7 @@
         "subtitle": "Operate big software at scale on any cloud",
         "description": "All the latest news on Juju – the open source application modelling tool for public and private clouds.",
         "url": "https://jujucharms.com",
-        "logo_url": "https://assets.ubuntu.com/v1/31c507a5-image-juju.svg",
+        "logo_url": "https://assets.ubuntu.com/v1/67057b2c-product-page-juju-logo.svg",
         "hero_url": "https://assets.ubuntu.com/v1/e8b86f15-Juju-Visual-Screen.png?w=576"
     },
     {
@@ -25,7 +25,7 @@
         "subtitle": "Metal as a Service",
         "description": "All the latest news on MAAS – the smartest way to manage bare metal.",
         "url": "https://maas.io",
-        "logo_url": "https://assets.ubuntu.com/v1/5f3d3c45-maas-logo-cropped.svg",
+        "logo_url": "https://assets.ubuntu.com/v1/0228cce3-product-page-maas-logo.svg",
         "hero_url": "https://assets.ubuntu.com/v1/e6c6b98f-Maas-Visual-Screen.png?w=576"
     },
     {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -171,3 +171,11 @@ pre {
     display: none !important;
   }
 }
+
+.p-topic-image {
+  max-height: 2.5rem;
+
+  @media (min-width: $breakpoint-medium) {
+    max-height: 3.5rem;
+  }
+}

--- a/templates/topics.html
+++ b/templates/topics.html
@@ -6,14 +6,18 @@
       <div class="col-6">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
+            {% if topic.name != 'Design' %}
+            <img class="p-topic-image" src="{{ topic.logo_url }}" alt=""/>
+            {% else %}
             <img class="p-heading-icon__img" src="{{ topic.logo_url }}" alt=""/>
             <h1 class="p-heading--one p-heading-icon__title">{{ topic.name }}</h1>
+            {% endif %}
           </div>
           <h2 class="p-heading--two">{{ topic.subtitle }}</h2>
           <p class="p-heading--five">{{ topic.description | safe }}</p>
         </div>
           <p>
-            <a class="p-link--external" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
+            <a class="p-link--external{% if topic.strip_css == 'p-strip--accent is-dark' %} p-link--inverted{% endif %}" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
           </p>
         </ul>
       </div>


### PR DESCRIPTION
# Done

- Changed Vanilla logo in Design topic page to Ubuntu logo
- Replaced MAAS and Juju logos with logo+text svgs

# Note

- Snapcraft logo to change from a different PR

# Issues

Fixes #135, fixes #136 