### PR TITLE
Replace snappy with snapcraft and new logo

### DIFF
--- a/data/topics.json
+++ b/data/topics.json
@@ -29,13 +29,13 @@
         "hero_url": "https://assets.ubuntu.com/v1/e6c6b98f-Maas-Visual-Screen.png?w=576"
     },
     {
-        "name": "Snappy",
+        "name": "Snapcraft",
         "slug": "snappy",
         "strip_css": "p-strip--accent is-dark",
-        "subtitle": "Package any app for any Linux platform",
+        "subtitle": "Package any app for any Linux and deliver updates directly",
         "description": "All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.",
         "url": "https://snapcraft.io",
-        "logo_url": "https://assets.ubuntu.com/v1/a861450c-snapcraft-logo.svg",
+        "logo_url": "https://assets.ubuntu.com/v1/b46c8d7d-snapcraft-logo-hor-white.svg",
         "hero_url": "https://assets.ubuntu.com/v1/a91f36a8-Snapcraft-Visual-Screen.png?w=576"
     }
 ]

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -173,10 +173,10 @@ pre {
 }
 
 .p-topic-image {
-  max-height: 2.5rem;
+  height: 2.5rem;
 
   @media (min-width: $breakpoint-medium) {
-    max-height: 3.5rem;
+    height: 3.5rem;
   }
 }
 

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -95,7 +95,7 @@
         <li><a href="/topics/design/">Design</a></li>
         <li><a href="/topics/juju/">Juju</a></li>
         <li><a href="/topics/maas/">MAAS</a></li>
-        <li><a href="/topics/snappy/">Snappy</a></li>
+        <li><a href="/topics/snappy/">Snapcraft</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">


### PR DESCRIPTION
## Done

- Replace snappy with snapcraft and new logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [snappy topic page](http://0.0.0.0:8023/topics/snappy/)
- see the new logo and that the name is snapcraft

## Issue / Card

Fixes #127

Signed-off-by: Peter Mahnke <peter@transitionelement.com>