### PR TITLE
Added logos and social to press centre

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,15 +93,6 @@ def group_category(group=[], category='all'):
         per_page=12
     )
 
-    return flask.render_template(
-        'group.html',
-        posts=posts,
-        group=groups if groups else None,
-        group_details=group_details,
-        category=category if category else None,
-        **metadata
-    )
-
     if group == 'canonical-announcements':
         return flask.render_template(
             'press-centre.html',
@@ -109,7 +100,6 @@ def group_category(group=[], category='all'):
             group=groups if groups else None,
             group_details=group_details,
             category=category if category else None,
-            featured_post=featured_post,
             **metadata
         )
     elif group:
@@ -119,7 +109,6 @@ def group_category(group=[], category='all'):
             group=groups if groups else None,
             group_details=group_details,
             category=category if category else None,
-            featured_post=featured_post,
             **metadata
         )
     else:

--- a/app.py
+++ b/app.py
@@ -73,7 +73,17 @@ def group_category(group=[], category='all'):
         'https://www.brighttalk.com/channel/6793/feed/rss'
     )
 
-    if group:
+    if group == 'canonical-announcements':
+        return flask.render_template(
+            'press-centre.html',
+            posts=posts,
+            group=groups if groups else None,
+            group_details=group_details,
+            category=category if category else None,
+            featured_post=featured_post,
+            **metadata
+        )
+    elif group:
         return flask.render_template(
             'group.html',
             posts=posts,

--- a/templates/group.html
+++ b/templates/group.html
@@ -5,11 +5,7 @@
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6 p-card--overlay">
         <h1 class="p-heading--one">
-          {% if request.path.startswith("/press-centre/") %}
-            Press centre
-          {% else %}
-            {{ group_details.name }}
-          {% endif %}
+          {{ group_details.name }}
         </h1>
         <h5 style="line-height: 1.75rem;">
           {{ group_details.description | safe }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,7 +78,7 @@
       <footer class="p-footer u-no-margin--top">
         <div class="row">
           <div class="col-12">
-            <p>© 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of <a href="http://canonical.com" title="Visit the Canonical website" class="p-link--external">Canonical Ltd</a></p>
+            <p>© 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of <a href="http://canonical.com" title="Visit the Canonical website" class="p-link--external">Canonical Ltd</a></p>
             <nav class="u-no-margin">
               <ul class="p-inline-list--middot">
                 <li class="p-inline-list__item"><a href="http://www.ubuntu.com/legal?_ga=2.109791751.30453126.1506352252-1019357392.1467192551" class="p-link--external">Legal information</a></li>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -1,0 +1,108 @@
+{% extends "layout.html" %}
+{% block body %}
+
+  <section class="p-strip--image  is-dark" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">
+    <div class="row u-equal-height u-vertically-center">
+      <div class="col-6 p-card--overlay">
+        <h1 class="p-heading--one">
+          Press centre
+        </h1>
+        <h5 style="line-height: 1.75rem;">
+          {{ group_details.description | safe }}
+        </h5>
+        {% if group_details.url %}
+        <p>
+          <a class="p-link--external" href="{{ group_details.url }}">Learn more about {{ group_details.name }}</a>
+        </p>
+        {% endif %}
+      </div>
+      <div id="rtp-banner" class="rtp-banner"></div>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+    <nav class="p-tabs col-12">
+      <div class="row">
+        <ul class="p-tabs__list" role="tablist">
+          {% if group_details.slug != 'canonical-announcements' %}
+          <li class="p-tabs__item" role="presentation">
+            <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/{{ group_details.slug }}/articles" class="p-tabs__link"  role="tab" aria-controls="section2" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/{{ group_details.slug }}/case-studies" class="p-tabs__link" role="tab" aria-controls="section3" {% if category == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/{{ group_details.slug }}/videos" class="p-tabs__link"  role="tab" aria-controls="section4" {% if category == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/{{ group_details.slug }}/webinars" class="p-tabs__link"  role="tab" aria-controls="section5" {% if category == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
+          </li>
+          {% endif %}
+        </ul>
+      </div>
+    </nav>
+  </section>
+
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+
+
+  {%- for post in posts %}
+    {% if loop.index0 % 2 == 0 %}
+    <div class="row u-equal-height u-clearfix">
+    {% endif %}
+      <div class="col-4 p-card--post">
+        <header class="p-card__header--{{ post.groups.slug }}">
+          <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
+        </header>
+        <div class="p-card__content">
+          <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
+          <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
+          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
+        </div>
+        <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+      </div>
+    {% if loop.index0 % 2 == 1 or loop.last %}
+    </div>
+    {% endif %}
+  {%- endfor %}
+  </div>
+  <div class="col-4">
+    <div class="p-card">
+      <h3>Logos</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/ubuntu-brandmark1.zip" title="Ubuntu logo pack zip file">Ubuntu logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/juju-brandmark1.zip" title="Juju logo pack zip file">Juju logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/canonical-brandmark1.zip" title="Canonical logo pack">Canonical logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+    <div class="p-card">
+      <h3>Follow us</h3>
+      <h5 class="p-muted-heading">Twitter</h5>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item"><a href="https://twitter.com/canonical" title="Follow us on @Canonical twitter">@Canonical</a></li>
+        <li class="p-inline-list__item"><a href="https://twitter.com/" title="Follow us on @Ubuntu twitter">@Ubuntu</a></li>
+        <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntuappdev" title="Follow us on @Ubuntuappdev twitter">@Ubuntuappdev</a></li>
+        <li class="p-inline-list__item"><a href="https://www.facebook.com/ubuntulinux" title="Follow us on facebook">Ubuntu</a></li>
+      </ul>
+      <h5 class="p-muted-heading">Google+</h5>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item"><a href="https://plus.google.com/+Ubuntu/posts" title="Follow us on Google+">Ubuntu</a></li>
+      </ul>
+      <h5 class="p-muted-heading">YouTube</h5>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>
+      </ul>
+      <h5 class="p-muted-heading">Twitter</h5>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntudev" title="Follow us on @Ubuntudev twitter">@Ubuntudev</a></li>
+        <li class="p-inline-list__item"><a href="https://twitter.com/UbuntuCloud" title="Follow us on @UbuntuCloud twitter">@UbuntuCloud</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -73,7 +73,7 @@
   </div>
   <div class="col-4">
     <div class="p-card">
-      <h3>Logos</h3>
+      <h4>Logos</h4>
       <ul class="p-list">
         <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/ubuntu-brandmark1.zip" title="Ubuntu logo pack zip file">Ubuntu logo pack [ZIP]&nbsp;&rsaquo;</a></li>
         <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/juju-brandmark1.zip" title="Juju logo pack zip file">Juju logo pack [ZIP]&nbsp;&rsaquo;</a></li>
@@ -81,7 +81,7 @@
       </ul>
     </div>
     <div class="p-card">
-      <h3>Follow us</h3>
+      <h4>Follow us</h4>
       <h5 class="p-muted-heading">Twitter</h5>
       <ul class="p-inline-list--middot">
         <li class="p-inline-list__item"><a href="https://twitter.com/canonical" title="Follow us on @Canonical twitter">@Canonical</a></li>
@@ -96,11 +96,6 @@
       <h5 class="p-muted-heading">YouTube</h5>
       <ul class="p-inline-list--middot">
         <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>
-      </ul>
-      <h5 class="p-muted-heading">Twitter</h5>
-      <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntudev" title="Follow us on @Ubuntudev twitter">@Ubuntudev</a></li>
-        <li class="p-inline-list__item"><a href="https://twitter.com/UbuntuCloud" title="Follow us on @UbuntuCloud twitter">@UbuntuCloud</a></li>
       </ul>
     </div>
   </div>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -46,58 +46,56 @@
     </nav>
   </section>
 
-  <div class="p-strip is-bordered">
+  <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
-
-
-  {%- for post in posts %}
-    {% if loop.index0 % 2 == 0 %}
-    <div class="row u-equal-height u-clearfix">
-    {% endif %}
-      <div class="col-4 p-card--post">
-        <header class="p-card__header--{{ post.groups.slug }}">
-          <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
-        </header>
-        <div class="p-card__content">
-          <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
-          <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
-          <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
+        {%- for post in posts %} {% if loop.index0 % 2 == 0 %}
+        <div class="row u-equal-height u-clearfix">
+          {% endif %}
+          <div class="col-4 p-card--post">
+            <header class="p-card__header--{{ post.groups.slug }}">
+              <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
+            </header>
+            <div class="p-card__content">
+              <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
+              <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
+              <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
+            </div>
+            <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+          </div>
+          {% if loop.index0 % 2 == 1 or loop.last %}
         </div>
-        <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+        {% endif %} {%- endfor %}
       </div>
-    {% if loop.index0 % 2 == 1 or loop.last %}
+      <div class="col-4">
+        <div class="p-card">
+          <h4>Logos</h4>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/ubuntu-brandmark1.zip" title="Ubuntu logo pack zip file">Ubuntu logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/juju-brandmark1.zip" title="Juju logo pack zip file">Juju logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/canonical-brandmark1.zip" title="Canonical logo pack">Canonical logo pack [ZIP]&nbsp;&rsaquo;</a></li>
+          </ul>
+        </div>
+        <div class="p-card">
+          <h4>Follow us</h4>
+          <h5 class="p-muted-heading">Twitter</h5>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item"><a href="https://twitter.com/canonical" title="Follow us on @Canonical twitter">@Canonical</a></li>
+            <li class="p-inline-list__item"><a href="https://twitter.com/" title="Follow us on @Ubuntu twitter">@Ubuntu</a></li>
+            <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntuappdev" title="Follow us on @Ubuntuappdev twitter">@Ubuntuappdev</a></li>
+            <li class="p-inline-list__item"><a href="https://www.facebook.com/ubuntulinux" title="Follow us on facebook">Ubuntu</a></li>
+          </ul>
+          <h5 class="p-muted-heading">Google+</h5>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item"><a href="https://plus.google.com/+Ubuntu/posts" title="Follow us on Google+">Ubuntu</a></li>
+          </ul>
+          <h5 class="p-muted-heading">YouTube</h5>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>
+          </ul>
+        </div>
+      </div>
     </div>
-    {% endif %}
-  {%- endfor %}
-  </div>
-  <div class="col-4">
-    <div class="p-card">
-      <h4>Logos</h4>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/ubuntu-brandmark1.zip" title="Ubuntu logo pack zip file">Ubuntu logo pack [ZIP]&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/juju-brandmark1.zip" title="Juju logo pack zip file">Juju logo pack [ZIP]&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/canonical-brandmark1.zip" title="Canonical logo pack">Canonical logo pack [ZIP]&nbsp;&rsaquo;</a></li>
-      </ul>
-    </div>
-    <div class="p-card">
-      <h4>Follow us</h4>
-      <h5 class="p-muted-heading">Twitter</h5>
-      <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a href="https://twitter.com/canonical" title="Follow us on @Canonical twitter">@Canonical</a></li>
-        <li class="p-inline-list__item"><a href="https://twitter.com/" title="Follow us on @Ubuntu twitter">@Ubuntu</a></li>
-        <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntuappdev" title="Follow us on @Ubuntuappdev twitter">@Ubuntuappdev</a></li>
-        <li class="p-inline-list__item"><a href="https://www.facebook.com/ubuntulinux" title="Follow us on facebook">Ubuntu</a></li>
-      </ul>
-      <h5 class="p-muted-heading">Google+</h5>
-      <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a href="https://plus.google.com/+Ubuntu/posts" title="Follow us on Google+">Ubuntu</a></li>
-      </ul>
-      <h5 class="p-muted-heading">YouTube</h5>
-      <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>
-      </ul>
-    </div>
-  </div>
-</div>
+  </section>
+
 {% endblock %}


### PR DESCRIPTION
## Done

- Created a new press-centre layout
- Added logos and social to press centre
- Still, need to add an Announcement based archive (see #146)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [the press centre](http://0.0.0.0:8023/press-centre/)
- See that the list matches the [copy doc](https://docs.google.com/document/d/1liiT3l86LHfIyYd_Neg5LAAMRa44VF5QlF63S2gph3Q/edit#)

## Issue / Card

Fixes #132
