### PR TITLE
Add group annual archives

### DIFF
--- a/app.py
+++ b/app.py
@@ -176,20 +176,16 @@ def archives_group_year(group, year):
 
 @app.route('/archives/<group>/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/')
 def archives_group_year_month(group, year, month):
-    group_id = ''
-    groups = []
-    if group:
-        if group == 'press-centre':
-            group = 'canonical-announcements'
+    if group == 'press-centre':
+        group = 'canonical-announcements'
 
-        groups = api.get_group_by_slug(group)
-        group_id = int(groups['id']) if groups else None
-        group_name = groups['name'] if groups else None
+    groups = api.get_group_by_slug(group)
+    if not groups:
+        flask.abort(404)
 
-        if not group_id:
-            return flask.render_template(
-                '404.html'
-            )
+    group_id = int(groups['id']) if groups else None
+    group_name = groups['name'] if groups else None
+
     result = api.get_archives(year, month, group_id, group_name)
     return flask.render_template('archives.html', result=result)
 

--- a/app.py
+++ b/app.py
@@ -155,6 +155,25 @@ def archives_year_month(year, month):
     result = api.get_archives(year, month)
     return flask.render_template('archives.html', result=result)
 
+@app.route('/archives/<group>/<regex("[0-9]{4}"):year>/')
+def archives_group_year(group, year):
+    group_id = ''
+    groups = []
+    if group:
+        if group == 'press-centre':
+            group = 'canonical-announcements'
+
+        groups = api.get_group_by_slug(group)
+        group_id = int(groups['id']) if groups else None
+        group_name = groups['name'] if groups else None
+
+        if not group_id:
+            return flask.render_template(
+                '404.html'
+            )
+    result = api.get_archives(year, None, group_id, group_name)
+    return flask.render_template('archives.html', result=result)
+
 @app.route('/archives/<group>/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/')
 def archives_group_year_month(group, year, month):
     group_id = ''


### PR DESCRIPTION
## Done

- Add group annual archives (e.g. /archives/press-centre/2018/)
- This is required by the press-centre design ... see the [copy doc](https://docs.google.com/document/d/1liiT3l86LHfIyYd_Neg5LAAMRa44VF5QlF63S2gph3Q/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [group archive page](http://0.0.0.0:8023/archives/press-centre/2018/)
- See that the page renders and the content looks ok.


## Issues

Fixes #151 and part of #146 