### PR TITLE
Updated press-centre right rail

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,6 +100,7 @@ def group_category(group=[], category='all'):
             group=groups if groups else None,
             group_details=group_details,
             category=category if category else None,
+            today=datetime.utcnow(),
             **metadata
         )
     else:
@@ -175,22 +176,26 @@ def archives_year_month(year, month):
 
 @app.route('/archives/<group>/<regex("[0-9]{4}"):year>/')
 def archives_group_year(group, year):
-    group_id = ''
-    groups = []
-    if group:
-        if group == 'press-centre':
-            group = 'canonical-announcements'
+    group_slug = group
 
-        groups = api.get_group_by_slug(group)
-        group_id = int(groups['id']) if groups else None
-        group_name = groups['name'] if groups else None
+    if group == 'press-centre':
+        group = 'canonical-announcements'
 
-        if not group_id:
-            return flask.render_template(
-                '404.html'
-            )
+    groups = api.get_group_by_slug(group)
+
+    if not groups:
+        flask.abort(404)
+
+    group_id = int(groups['id']) if groups else None
+    group_name = groups['name'] if groups else None
+
     result = api.get_archives(year, None, group_id, group_name)
-    return flask.render_template('archives.html', result=result)
+    return flask.render_template(
+        'archives.html',
+        result=result,
+        group=group_slug,
+        today=datetime.utcnow(),
+    )
 
 
 @app.route(

--- a/templates/archive-list.html
+++ b/templates/archive-list.html
@@ -1,14 +1,15 @@
 <ul class="p-list">
   {% for year in range(today.year,2006,-1) %}
-  <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/{{ year }}/">{{ year }}</a></h5>
-    <ul class="p-inline-list--middot">
-    {% for month in range(1, 13, 1) %}
-      {# need to skip months in the current year that haven't occured #}
-      {% if today.year != year or (today.year == year and month <= today.month) %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/archives/{{ year }}/{% if month < 10 %}0{% endif %}{{ month }}">{{ month | monthname }}</a></li>
-      {% endif %}
-    {% endfor %}
-    </li>
-  </ul>
+    <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/{% if group %}{{ group }}/{% endif %}{{ year }}/">{{ year }}</a></h5>
+    {% if not group %}
+      <ul class="p-inline-list--middot">
+        {% for month in range(1, 13, 1) %}
+          {# need to skip months in the current year that haven't occured #}
+          {% if today.year != year or (today.year == year and month <= today.month) %}
+            <li class="p-inline-list__item"><a class="p-link--soft" href="/archives/{{ year }}/{% if month < 10 %}0{% endif %}{{ month }}">{{ month | monthname }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </li>
+    {% endif %}
   {% endfor %}
 </ul>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -72,7 +72,6 @@
           <h4>Logos</h4>
           <ul class="p-list">
             <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/ubuntu-brandmark1.zip" title="Ubuntu logo pack zip file">Ubuntu logo pack [ZIP]&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/juju-brandmark1.zip" title="Juju logo pack zip file">Juju logo pack [ZIP]&nbsp;&rsaquo;</a></li>
             <li class="p-list__item is-ticked"><a href="https://insights.ubuntu.com/wp-content/uploads/226b/canonical-brandmark1.zip" title="Canonical logo pack">Canonical logo pack [ZIP]&nbsp;&rsaquo;</a></li>
           </ul>
         </div>
@@ -81,8 +80,10 @@
           <h5 class="p-muted-heading">Twitter</h5>
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item"><a href="https://twitter.com/canonical" title="Follow us on @Canonical twitter">@Canonical</a></li>
-            <li class="p-inline-list__item"><a href="https://twitter.com/" title="Follow us on @Ubuntu twitter">@Ubuntu</a></li>
-            <li class="p-inline-list__item"><a href="https://twitter.com/Ubuntuappdev" title="Follow us on @Ubuntuappdev twitter">@Ubuntuappdev</a></li>
+            <li class="p-inline-list__item"><a href="https://twitter.com/ubuntu" title="Follow us on @Ubuntu twitter">@Ubuntu</a></li>
+          </ul>
+          <h5 class="p-muted-heading">Facebook</h5>
+          <ul class="p-inline-list--middot">
             <li class="p-inline-list__item"><a href="https://www.facebook.com/ubuntulinux" title="Follow us on facebook">Ubuntu</a></li>
           </ul>
           <h5 class="p-muted-heading">Google+</h5>
@@ -92,6 +93,18 @@
           <h5 class="p-muted-heading">YouTube</h5>
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>
+          </ul>
+          <h5 class="p-muted-heading">LinkedIn</h5>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item"><a href="https://www.linkedin.com/company/234280/" title="Follow us on LinkedIn">Canonical</a></li>
+          </ul>
+        </div>
+        <div class="p-card">
+          <h4>Archives</h4>
+          <ul class="p-list">
+            {% for year in range(today.year,2005,-1) %}
+              <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/press-centre/{{ year }}/">{{ year }}</a></h5></li>
+            {% endfor %}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated press-centre right rail
- Added yearly archive
- Added group archive to the archive pages (with only years)
- Updated social list
- Remove juju logos

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [press-centre](http://0.0.0.0:8023/press-centre/)
- See that it matches the [copy doc](https://docs.google.com/document/d/1liiT3l86LHfIyYd_Neg5LAAMRa44VF5QlF63S2gph3Q/edit#) and the archives work (lots of missing archives pre-2015!!!

## Issue / Card

Fixes #146
