### PR TITLE
Move search to /search

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,18 +33,6 @@ app.url_map.converters['regex'] = RegexConverter
 
 @app.route('/')
 def homepage():
-    search = flask.request.args.get('q')
-
-    if search:
-        result = {}
-
-        posts = api.search_posts(search)
-
-        result["posts"] = posts
-        result["count"] = len(posts)
-        result["query"] = search
-        return flask.render_template('search.html', result=result)
-
     page = flask.request.args.get('page')
     posts, metadata = api.get_posts(page=page, per_page=13)
 
@@ -65,6 +53,22 @@ def homepage():
         featured_post=featured_post,
         webinars=webinars,
         **metadata
+    )
+
+
+@app.route('/search/')
+def search():
+    query = flask.request.args.get('q') or ''
+
+    posts = api.search_posts(query) if query else []
+
+    return flask.render_template(
+        'search.html',
+        result={
+            "posts": posts,
+            "count": len(posts),
+            "query": query
+        }
     )
 
 

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -102,7 +102,7 @@
       <a href="/press-centre/">Press centre</a>
     </li>
   </ul>
-  <form class="p-search-box" action="/">
+  <form class="p-search-box" action="/search">
     <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
     <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
     <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,15 +2,17 @@
 
 {% block body %}
   <section id="main-content" class="p-strip--accent is-dark is-deep">
+    {% if result.query %}
     <div class="row">
       <div class="col-10">
         <h2>We&rsquo;ve found  {{ result.count }} results for &ldquo;{{ result.query }}&rdquo;</h2>
       </div>
     </div>
+    {% endif %}
     <div class="row">
       <div class="col-10">
         <div class="p-form__group">
-          <form class="p-search-box" action="/">
+          <form class="p-search-box" action="/search">
             <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="" value="{{ result.query }}" >
             <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
             <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>


### PR DESCRIPTION
This mirrors how we decided to do it in snapcraft.io, which was quite
carefully considered. We believe that "domain.com/search?q=" is a
more descriptive URL for the user to see than "domein.com/?q=". "/?q="
might be better for an API, but for a website, /search is more usable.

This also has added benefits for development, because "/search" leading
to the "search.html" template is more intuitive, and we can now keep the
logic for "/search" in its own routing function.

QA
--

`./run`, and go to http://127.0.0.1:8023/search. Do some searches. Also use the search box in the header from many different pages on the site.