### PR TITLE
Fix redirects

### DIFF
--- a/app.py
+++ b/app.py
@@ -235,19 +235,6 @@ def user(slug):
     return flask.render_template('author.html', author=api.get_author(slug))
 
 
-@app.route('/admin/')
-@app.route('/feed/')
-@app.route('/wp-content/')
-@app.route('/wp-includes/')
-@app.route('/wp-login.php/')
-def redirect_wordpress_login():
-    path = flask.request.path
-    if (flask.request.args):
-        path = '?'.join([path, urllib.parse.urlencode(flask.request.args)])
-
-    return flask.redirect(INSIGHTS_URL + path)
-
-
 @app.errorhandler(404)
 def page_not_found(e):
     return flask.render_template('404.html'), 404

--- a/app.py
+++ b/app.py
@@ -1,6 +1,3 @@
-# Core
-import urllib
-
 # Third-party
 import flask
 from datetime import datetime

--- a/app.py
+++ b/app.py
@@ -3,14 +3,15 @@ import urllib
 
 # Third-party
 import flask
-from flask import request
+from datetime import datetime
+from werkzeug.routing import BaseConverter
 
 # Local
 import api
 import local_data
 import helpers
-from werkzeug.routing import BaseConverter
-from datetime import datetime
+import redirects
+
 
 INSIGHTS_URL = 'https://insights.ubuntu.com'
 
@@ -24,12 +25,18 @@ class RegexConverter(BaseConverter):
         self.regex = items[0]
 
 
+apply_redirects = redirects.prepare_redirects(
+    permanent_redirects_path='permanent-redirects.yaml',
+    redirects_path='redirects.yaml'
+)
+app.before_request(apply_redirects)
+
 app.url_map.converters['regex'] = RegexConverter
 
 
 @app.route('/')
 def homepage():
-    search = request.args.get('q')
+    search = flask.request.args.get('q')
 
     if search:
         result = {}

--- a/redirects.py
+++ b/redirects.py
@@ -1,0 +1,97 @@
+# Core
+import os
+import re
+
+# External
+import flask
+import yaml
+import yamlordereddictloader
+
+
+class YamlRegexMap:
+    def __init__(self, filepath):
+        """
+        Given the path to a YAML file of RegEx mappings like:
+
+            hello/(?P<person>.*)?: "/say-hello?name={person}"
+            google/(?P<search>.*)?: "https://google.com/?q={search}"
+
+        Return a list of compiled Regex matches and destination strings:
+
+            [
+                (<regex>, "/say-hello?name={person}"),
+                (<regex>, "https://google.com/?q={search}"),
+            ]
+        """
+
+        self.matches = []
+
+        if os.path.isfile(filepath):
+            with open(filepath) as redirects_file:
+                lines = yaml.load(
+                    redirects_file,
+                    Loader=yamlordereddictloader.Loader
+                )
+
+                if lines:
+                    for url_match, target_url in lines.items():
+                        if url_match[0] != '/':
+                            url_match = '/' + url_match
+
+                        self.matches.append(
+                            (re.compile(url_match), target_url)
+                        )
+
+    def get_target(self, url_path):
+        for (match, target) in self.matches:
+            result = match.fullmatch(url_path)
+
+            if result:
+                parts = {}
+                for name, value in result.groupdict().items():
+                    parts[name] = value or ''
+                return target.format(**parts)
+
+
+def prepare_redirects(
+    permanent_redirects_path='permanent-redirects.yaml',
+    redirects_path='redirects.yaml'
+):
+    """
+    Create a regex map from the provided yaml files,
+    and return a view function "apply_redirects" which encloses
+    the maps to apply redirect where relevant.
+
+    Usage:
+
+        import flask
+        from redirects import prepare_redirects
+        app = flask.Flask(__name__)
+        apply_redirects = prepare_redirects(
+            permanent_redirects_path='permanent-redirects.yaml',
+            redirects_path='redirects.yaml'
+        )
+        app.before_request(apply_redirects)
+    """
+
+    permanent_redirect_map = YamlRegexMap(permanent_redirects_path)
+    redirect_map = YamlRegexMap(redirects_path)
+
+    def apply_redirects():
+        """
+        Process the two mappings defined above
+        of permanent and temporary redirects to target URLs,
+        to send the appropriate redirect responses
+        """
+
+        permanent_redirect_url = permanent_redirect_map.get_target(
+            flask.request.path
+        )
+        if permanent_redirect_url:
+            return flask.redirect(permanent_redirect_url, code=301)
+
+        redirect_url = redirect_map.get_target(flask.request.path)
+        if redirect_url:
+            return flask.redirect(redirect_url)
+
+    return apply_redirects

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,3 @@
+/admin(?P<page>/.*)?: https://admin.insights.ubuntu.com/admin{page}
+/feed(?P<page>/.*)?: https://admin.insights.ubuntu.com/feed{page}
+/wp-(?P<page>.*)?: https://admin.insights.ubuntu.com/wp-{page}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ requests==2.18.4
 requests-cache==0.4.13
 urllib3==1.22
 Werkzeug==0.12.2
+yamlordereddictloader==0.4.0
+pyyaml==3.12

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,7 +84,7 @@
                 <li class="p-inline-list__item"><a href="http://www.ubuntu.com/legal?_ga=2.109791751.30453126.1506352252-1019357392.1467192551" class="p-link--external">Legal information</a></li>
                 <li class="p-inline-list__item"><a href="http://www.ubuntu.com/privacy-policy" class="p-link--external">Privacy policy</a></li>
                 <li class="p-inline-list__item"><a class="screen-only p-link--external" href="https://github.com/canonical-websites/insights.ubuntu.com/issues">Report a bug on this site</a></li>
-                <li class="p-inline-list__item"><a href="https://insights.ubuntu.com/feed/">RSS feed</a></li>
+                <li class="p-inline-list__item"><a href="/feed/">RSS feed</a></li>
               </ul>
               <span class="u-off-screen">
                 <a href="#">Go to the top of the page</a>


### PR DESCRIPTION
Fixes #165

- Add a module to parse redirects.yaml
- Move redirects from app.py to redirects.yaml
- Change feed link to be relative (/feed/ instead of {domain}/feed/)

QA
--

`./run`

- Click the "RSS feed" link on the homepage - check you end up on admin.insights.ubuntu.com
- Manually check http://0.0.0.0:8023/feed/ takes you to https://admin.insights.ubuntu.com/feed/
- Check http://127.0.0.1:8023/wp-content/uploads/c9fa/0-Cover-Image-Spectre-Meltdown.png takes you to https://admin.insights.ubuntu.com/wp-content/uploads/c9fa/0-Cover-Image-Spectre-Meltdown.png, and loads the image