### PR TITLE
Remove slashes from all URLs

### DIFF
--- a/api.py
+++ b/api.py
@@ -67,7 +67,7 @@ def _embed_post_data(post):
 def _normalise_user(user):
     link = user['link']
     path = urlsplit(link).path
-    user['relative_link'] = path
+    user['relative_link'] = path.rstrip('/')
     return user
 
 
@@ -105,7 +105,7 @@ def _normalise_posts(posts, groups_id=None):
 def _normalise_post(post, groups_id=None):
     link = post['link']
     path = urlsplit(link).path
-    post['relative_link'] = path
+    post['relative_link'] = path.rstrip('/')
     post['formatted_date'] = datetime.datetime.strftime(
         dateutil.parser.parse(post['date']),
         "%d %B %Y"

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # Core
-from urllib.parse import urlparse, urlunparse, unquote
+from urllib.parse import urlencode, urlparse, urlunparse, unquote
 
 # Third-party
 import flask
@@ -94,8 +94,8 @@ def search():
     )
 
 
-@app.route('/<group_slug>/')
-@app.route('/<group_slug>/<category_slug>/')
+@app.route('/<group_slug>')
+@app.route('/<group_slug>/<category_slug>')
 def group_category(group_slug, category_slug='all'):
     if group_slug == 'press-centre':
         group_slug = 'canonical-announcements'
@@ -141,7 +141,7 @@ def group_category(group_slug, category_slug='all'):
         )
 
 
-@app.route('/topics/<slug>/')
+@app.route('/topics/<slug>')
 def topic_name(slug):
     topic = local_data.get_topic_details(slug)
 
@@ -163,7 +163,7 @@ def topic_name(slug):
     )
 
 
-@app.route('/tag/<slug>/')
+@app.route('/tag/<slug>')
 def tag_index(slug):
     response_json = api.get_tag(slug)
 
@@ -181,7 +181,7 @@ def tag_index(slug):
         )
 
 
-@app.route('/archives/<regex("[0-9]{4}"):year>/')
+@app.route('/archives/<regex("[0-9]{4}"):year>')
 def archives_year(year):
     result = api.get_archives(year)
     return flask.render_template(
@@ -191,7 +191,7 @@ def archives_year(year):
     )
 
 
-@app.route('/archives/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/')
+@app.route('/archives/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>')
 def archives_year_month(year, month):
     result = api.get_archives(year, month)
     return flask.render_template(
@@ -201,7 +201,7 @@ def archives_year_month(year, month):
     )
 
 
-@app.route('/archives/<group>/<regex("[0-9]{4}"):year>/')
+@app.route('/archives/<group>/<regex("[0-9]{4}"):year>')
 def archives_group_year(group, year):
     group_slug = group
 
@@ -226,7 +226,7 @@ def archives_group_year(group, year):
 
 
 @app.route(
-    '/archives/<group>/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/'
+    '/archives/<group>/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>'
 )
 def archives_group_year_month(group, year, month):
     if group == 'press-centre':
@@ -244,16 +244,16 @@ def archives_group_year_month(group, year, month):
 
 
 @app.route(
-    '/<regex("[0-9]{4}"):year>'
-    '/<regex("[0-9]{2}"):month>'
-    '/<regex("[0-9]{2}"):day>'
-    '/<slug>/'
+    '/<regex("[0-9]{4}"):year>/'
+    '/<regex("[0-9]{2}"):month>/'
+    '/<regex("[0-9]{2}"):day>/'
+    '/<slug>'
 )
 def post(year, month, day, slug):
     return flask.render_template('post.html', post=api.get_post(slug))
 
 
-@app.route('/author/<slug>/')
+@app.route('/author/<slug>')
 def user(slug):
     return flask.render_template('author.html', author=api.get_author(slug))
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # Core
-from urllib.parse import urlencode, urlparse, urlunparse, unquote
+from urllib.parse import urlparse, urlunparse, unquote
 
 # Third-party
 import flask
@@ -244,9 +244,9 @@ def archives_group_year_month(group, year, month):
 
 
 @app.route(
-    '/<regex("[0-9]{4}"):year>/'
-    '/<regex("[0-9]{2}"):month>/'
-    '/<regex("[0-9]{2}"):day>/'
+    '/<regex("[0-9]{4}"):year>'
+    '/<regex("[0-9]{2}"):month>'
+    '/<regex("[0-9]{2}"):day>'
     '/<slug>'
 )
 def post(year, month, day, slug):

--- a/templates/archive-list.html
+++ b/templates/archive-list.html
@@ -1,6 +1,6 @@
 <ul class="p-list">
   {% for year in range(today.year,2006,-1) %}
-    <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/{% if group %}{{ group }}/{% endif %}{{ year }}/">{{ year }}</a></h5>
+    <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/{% if group %}{{ group }}/{% endif %}{{ year }}">{{ year }}</a></h5>
     {% if not group %}
       <ul class="p-inline-list--middot">
         {% for month in range(1, 13, 1) %}

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -46,21 +46,21 @@
       <button class="p-accordion__tab" id="topics-tab" role="tab" aria-controls="#topics" aria-expanded="false">Topics</button>
       <div class="p-accordion__panel" id="topics" role="tabpanel" aria-hidden="true" aria-labelledby="topics-tab">
         <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/topics/design/">Design</a></li>
-          <li class="p-navigation__link"><a href="/topics/juju/">Juju</a></li>
-          <li class="p-navigation__link"><a href="/topics/maas/">MAAS</a></li>
-          <li class="p-navigation__link"><a href="/topics/snappy/">Snappy</a></li>
+          <li class="p-navigation__link"><a href="/topics/design">Design</a></li>
+          <li class="p-navigation__link"><a href="/topics/juju">Juju</a></li>
+          <li class="p-navigation__link"><a href="/topics/maas">MAAS</a></li>
+          <li class="p-navigation__link"><a href="/topics/snappy">Snappy</a></li>
         </ul>
       </div>
     </li>
     <li class="p-navigation__link">
-      <a href="/press-centre/">Press centre</a>
+      <a href="/press-centre">Press centre</a>
     </li>
   </ul>
   <!-- Large screen nav -->
   <ul class="p-navigation__links u-hide--nav-small">
     <li class="p-navigation__link">
-      <a href="/cloud-and-server/">Cloud and Server</a>
+      <a href="/cloud-and-server">Cloud and Server</a>
       <ul class="hover-menu">
         <li><a href="/cloud-and-server/all">All</a></li>
         <li><a href="/cloud-and-server/articles">Articles</a></li>
@@ -70,7 +70,7 @@
       </ul>
     </li>
     <li class="p-navigation__link">
-      <a href="/internet-of-things/">IoT</a>
+      <a href="/internet-of-things">IoT</a>
       <ul class="hover-menu">
         <li><a href="/internet-of-things/all">All</a></li>
         <li><a href="/internet-of-things/articles">Articles</a></li>
@@ -80,7 +80,7 @@
       </ul>
     </li>
     <li class="p-navigation__link">
-      <a href="/desktop/">Desktop</a>
+      <a href="/desktop">Desktop</a>
       <ul class="hover-menu">
         <li><a href="/desktop/all">All</a></li>
         <li><a href="/desktop/articles">Articles</a></li>
@@ -92,14 +92,14 @@
     <li class="p-navigation__link">
       <a href="#">Topics</a>
       <ul class="hover-menu">
-        <li><a href="/topics/design/">Design</a></li>
-        <li><a href="/topics/juju/">Juju</a></li>
-        <li><a href="/topics/maas/">MAAS</a></li>
-        <li><a href="/topics/snappy/">Snapcraft</a></li>
+        <li><a href="/topics/design">Design</a></li>
+        <li><a href="/topics/juju">Juju</a></li>
+        <li><a href="/topics/maas">MAAS</a></li>
+        <li><a href="/topics/snappy">Snapcraft</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">
-      <a href="/press-centre/">Press centre</a>
+      <a href="/press-centre">Press centre</a>
     </li>
   </ul>
   <form class="p-search-box" action="/search">

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -103,7 +103,7 @@
           <h4>Archives</h4>
           <ul class="p-list">
             {% for year in range(today.year,2005,-1) %}
-              <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/press-centre/{{ year }}/">{{ year }}</a></h5></li>
+              <li class="p-list__item"><h5><a class="p-link--soft" href="/archives/press-centre/{{ year }}">{{ year }}</a></h5></li>
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
Follow the snapcraft.io URL scheme of removing slashes from URL endpoints. This follows what GitHub, Facebook et. al do as well.

It also means I can more easily copy URL testing code from the snapcraft.io app.

- Make URLs with slashes (example.com/something/) redirect to remove the slash (example.com/something)
- Go through the templates and change links to not have slashes (to avoid extra redirect)
- When using URLs from the API, remove slashes from the end

QA
--

`./run`

Go through the site and check:

- All links work
- That URLs on links don't have slashes