### PR TITLE
Get rid of /all endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,35 +116,18 @@ def search():
 
 
 @app.route('/press-centre')
-@app.route('/press-centre/<category_slug>')
-def press_centre(group_slug, category_slug=''):
-    try:
-        group = local_data.get_group_by_slug('canonical-announcements')
-    except KeyError:
-        flask.abort(404)
+def press_centre():
+    group = local_data.get_group_by_slug('canonical-announcements')
+    group_details = local_data.get_group_details('canonical-announcements')
 
-    if not group:
-        flask.abort(404)
-
-    group_details = local_data.get_group_details(group_slug)
-    category = local_data.get_category_by_slug(category_slug)
-
-    page = flask.request.args.get('page')
-    posts, metadata = api.get_posts(
-        groups_id=group['id'],
-        categories=[category['id']] if category and category['id'] else [],
-        page=page,
-        per_page=12
-    )
+    posts, metadata = api.get_posts(groups_id=group['id'], per_page=12)
 
     return flask.render_template(
         'press-centre.html',
         posts=posts,
         group=group,
         group_details=group_details,
-        category=category if category else None,
         today=datetime.utcnow(),
-        **metadata
     )
 
 
@@ -153,20 +136,24 @@ def press_centre(group_slug, category_slug=''):
 def group_category(group_slug, category_slug=''):
     try:
         group = local_data.get_group_by_slug(group_slug)
+        group_details = local_data.get_group_details(group_slug)
     except KeyError:
         flask.abort(404)
 
-    if not group:
-        flask.abort(404)
+    category_ids = []
 
-    group_details = local_data.get_group_details(group_slug)
-
-    category = local_data.get_category_by_slug(category_slug)
+    if category_slug:
+        try:
+            category_ids = [
+                local_data.get_category_by_slug(category_slug)['id']
+            ]
+        except KeyError:
+            flask.abort(404)
 
     page = flask.request.args.get('page')
     posts, metadata = api.get_posts(
         groups_id=group['id'],
-        categories=[category['id']] if category and category['id'] else [],
+        categories=category_ids,
         page=page,
         per_page=12
     )
@@ -254,7 +241,7 @@ def archives_group_year(group, year):
     if group == 'press-centre':
         group = 'canonical-announcements'
 
-    groups = api.get_group_by_slug(group)
+    groups = local_data.get_group_by_slug(group)
 
     if not groups:
         flask.abort(404)

--- a/templates/group.html
+++ b/templates/group.html
@@ -26,7 +26,7 @@
         <ul class="p-tabs__list" role="tablist">
           {% if group_details.slug != 'canonical-announcements' %}
           <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
+            <a href="/{{ group_details.slug }}" class="p-tabs__link"  role="tab" aria-controls="section1" {% if not category %} aria-selected="true"{% endif %}>All</a>
           </li>
           <li class="p-tabs__item" role="presentation">
             <a href="/{{ group_details.slug }}/articles" class="p-tabs__link"  role="tab" aria-controls="section2" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -10,7 +10,7 @@
       <button class="p-accordion__tab" id="cloud-tab" role="tab" aria-controls="#cloud" aria-expanded="false">Cloud and Server</button>
       <div class="p-accordion__panel" id="cloud" role="tabpanel" aria-hidden="true" aria-labelledby="cloud-tab">
         <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/cloud-and-server/all">All</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server">All</a></li>
           <li class="p-navigation__link"><a href="/cloud-and-server/articles">Articles</a></li>
           <li class="p-navigation__link"><a href="/cloud-and-server/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/cloud-and-server/videos">Videos</a></li>
@@ -22,7 +22,7 @@
       <button class="p-accordion__tab" id="iot-tab" role="tab" aria-controls="#iot" aria-expanded="false">IoT</button>
       <div class="p-accordion__panel" id="iot" role="tabpanel" aria-hidden="true" aria-labelledby="iot-tab">
         <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/internet-of-things/all">All</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things">All</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things/articles">Articles</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things/videos">Videos</a></li>
@@ -34,7 +34,7 @@
       <button class="p-accordion__tab" id="desktop-tab" role="tab" aria-controls="#desktop" aria-expanded="false">Desktop</button>
       <div class="p-accordion__panel" id="desktop" role="tabpanel" aria-hidden="true" aria-labelledby="desktop-tab">
         <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/desktop/all">All</a></li>
+          <li class="p-navigation__link"><a href="/desktop">All</a></li>
           <li class="p-navigation__link"><a href="/desktop/articles">Articles</a></li>
           <li class="p-navigation__link"><a href="/desktop/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/desktop/videos">Videos</a></li>
@@ -62,7 +62,7 @@
     <li class="p-navigation__link">
       <a href="/cloud-and-server">Cloud and Server</a>
       <ul class="hover-menu">
-        <li><a href="/cloud-and-server/all">All</a></li>
+        <li><a href="/cloud-and-server">All</a></li>
         <li><a href="/cloud-and-server/articles">Articles</a></li>
         <li><a href="/cloud-and-server/case-studies">Case Studies</a></li>
         <li><a href="/cloud-and-server/videos">Videos</a></li>
@@ -72,7 +72,7 @@
     <li class="p-navigation__link">
       <a href="/internet-of-things">IoT</a>
       <ul class="hover-menu">
-        <li><a href="/internet-of-things/all">All</a></li>
+        <li><a href="/internet-of-things">All</a></li>
         <li><a href="/internet-of-things/articles">Articles</a></li>
         <li><a href="/internet-of-things/case-studies">Case Studies</a></li>
         <li><a href="/internet-of-things/videos">Videos</a></li>
@@ -82,7 +82,7 @@
     <li class="p-navigation__link">
       <a href="/desktop">Desktop</a>
       <ul class="hover-menu">
-        <li><a href="/desktop/all">All</a></li>
+        <li><a href="/desktop">All</a></li>
         <li><a href="/desktop/articles">Articles</a></li>
         <li><a href="/desktop/case-studies">Case Studies</a></li>
         <li><a href="/desktop/videos">Videos</a></li>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -20,48 +20,26 @@
     </div>
   </section>
 
-  <section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-    <nav class="p-tabs col-12">
-      <div class="row">
-        <ul class="p-tabs__list" role="tablist">
-          {% if group_details.slug != 'canonical-announcements' %}
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/articles" class="p-tabs__link"  role="tab" aria-controls="section2" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/case-studies" class="p-tabs__link" role="tab" aria-controls="section3" {% if category == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/videos" class="p-tabs__link"  role="tab" aria-controls="section4" {% if category == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/webinars" class="p-tabs__link"  role="tab" aria-controls="section5" {% if category == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-          </li>
-          {% endif %}
-        </ul>
-      </div>
-    </nav>
-  </section>
-
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
-        {%- for post in posts %}
-        <div class="p-card--post">
-          <header class="p-card__header--{{ post.groups.slug }}">
-            <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
-          </header>
-          <div class="p-card__content">
-            <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
-            <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
-            <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
+        {%- for post in posts %} {% if loop.index0 % 2 == 0 %}
+        <div class="row u-equal-height u-clearfix">
+          {% endif %}
+          <div class="col-4 p-card--post">
+            <header class="p-card__header--{{ post.groups.slug }}">
+              <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
+            </header>
+            <div class="p-card__content">
+              <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
+              <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
+              <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
+            </div>
+            <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
           </div>
-          <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+          {% if loop.index0 % 2 == 1 or loop.last %}
         </div>
-        {%- endfor %}
+        {% endif %} {%- endfor %}
       </div>
       <div class="col-4">
         <div class="p-card">
@@ -106,7 +84,5 @@
       </div>
     </div>
   </section>
-
-  {% include "pagination.html" %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #181

`/{group}` URLs duplicate `/{group}/all` URLs. There's no need for `/all`, it just complicates the app.

Remove all `/all` links.

QA
--

`./run`

Browse around group pages and press centre, check nothing breaks.