### PR TITLE
Moved filters from tab to dropdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,7 @@ def homepage():
 
 
 @app.route(
-    '/<regex("(videos|case-studies|webinars|articles)"):category_slug>'
+    '/<regex("(videos|whitepapers|case-studies|webinars|articles)"):category_slug>'
 )
 def category(category_slug):
     category = local_data.get_category_by_slug(category_slug)

--- a/app.py
+++ b/app.py
@@ -79,7 +79,9 @@ def homepage():
 
 
 @app.route(
-    '/<regex("(videos|whitepapers|case-studies|webinars|articles)"):category_slug>'
+    '/<regex(\
+        "(videos|whitepapers|case-studies|webinars|articles)"\
+    ):category_slug>'
 )
 def category(category_slug):
     category = local_data.get_category_by_slug(category_slug)

--- a/data/groups.json
+++ b/data/groups.json
@@ -11,7 +11,7 @@
         "slug": "internet-of-things",
         "description": "A new, snappy, transactionally updated Ubuntu for clouds and devices.",
         "url": "https://www.ubuntu.com/things",
-        "hero_url": "https://assets.ubuntu.com/v1/ee9a6ce3-drone-iceland-unsplash.jpg"
+        "hero_url": "https://assets.ubuntu.com/v1/d1d58769-drone-iceland-unsplash-no-logo.jpg"
     },
     {
         "name": "Desktop",

--- a/templates/category.html
+++ b/templates/category.html
@@ -87,30 +87,6 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-  <nav class="p-tabs col-12">
-    <div class="row">
-      <ul class="p-tabs__list" role="tablist">
-        <li class="p-tabs__item" role="presentation">
-          <a href="/" class="p-tabs__link" role="tab" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/articles" class="p-tabs__link" role="tab" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/case-studies" class="p-tabs__link" role="tab" {% if category == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/videos" class="p-tabs__link" role="tab" {% if category == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/webinars" class="p-tabs__link" role="tab" {% if category == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-        </li>
-      </ul>
-    </div>
-  </nav>
-</section>
-
   {% include "posts.html" %}
 
 {% endblock %}

--- a/templates/group.html
+++ b/templates/group.html
@@ -20,32 +20,6 @@
     </div>
   </section>
 
-  <section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-    <nav class="p-tabs col-12">
-      <div class="row">
-        <ul class="p-tabs__list" role="tablist">
-          {% if group_details.slug != 'canonical-announcements' %}
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/all" class="p-tabs__link"  role="tab" aria-controls="section1" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/articles" class="p-tabs__link"  role="tab" aria-controls="section2" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/case-studies" class="p-tabs__link" role="tab" aria-controls="section3" {% if category == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/videos" class="p-tabs__link"  role="tab" aria-controls="section4" {% if category == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/{{ group_details.slug }}/webinars" class="p-tabs__link"  role="tab" aria-controls="section5" {% if category == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-          </li>
-          {% endif %}
-        </ul>
-      </div>
-    </nav>
-  </section>
-
   {% include "posts.html" %}
 
   {% include "pagination.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block body %}
 
-<section class="p-strip--image is-dark p-takeover" style="background: #111111; background-size: cover; background-image: url('https://assets.ubuntu.com/v1/3e3de22c-UPM-background.png'); background-position: 77% 0%;">
+<section class="p-strip--image is-dark p-takeover" style="background: #111111; background-size: cover; background-image: url('https://assets.ubuntu.com/v1/3e3de22c-UPM-background.png'); background-position: 77% 60%;">
   <div class="row u-vertically-center">
     <div class="col-6">
       <h1 class="p-heading--one">
@@ -12,7 +12,7 @@
       </p>
     </div>
     <div class="col-5 prefix-1 u-align--center u-hide--small">
-      <svg class="upm-svg" xmlns="http://www.w3.org/2000/svg" height="350px" width="400px" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 400 350">
+      <svg class="upm-svg" xmlns="http://www.w3.org/2000/svg" height="300px" width="100%" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 400 350">
         <title></title>
         <g fill-rule="evenodd" fill="none">
           <g>
@@ -85,30 +85,6 @@
       </svg>
     </div>
   </div>
-</section>
-
-<section class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-  <nav class="p-tabs col-12">
-    <div class="row">
-      <ul class="p-tabs__list" role="tablist">
-        <li class="p-tabs__item" role="presentation">
-          <a href="/" class="p-tabs__link"  role="tab" {% if category == 'all' %} aria-selected="true"{% endif %}>All</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/articles" class="p-tabs__link"  role="tab" {% if category == 'articles' %} aria-selected="true"{% endif %}>Articles</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/case-studies" class="p-tabs__link" role="tab" {% if category == 'case-studies' %} aria-selected="true"{% endif %}>Case Studies</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/videos" class="p-tabs__link"  role="tab" {% if category == 'videos' %} aria-selected="true"{% endif %}>Videos</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/webinars" class="p-tabs__link"  role="tab" {% if category == 'webinars' %} aria-selected="true"{% endif %}>Webinars</a>
-        </li>
-      </ul>
-    </div>
-  </nav>
 </section>
 
 {% if featured_post %}

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -15,6 +15,7 @@
           <li class="p-navigation__link"><a href="/cloud-and-server/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/cloud-and-server/videos">Videos</a></li>
           <li class="p-navigation__link"><a href="/cloud-and-server/webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server/whitepapers">Whitepapers</a></li>
         </ul>
       </div>
     </li>
@@ -27,6 +28,7 @@
           <li class="p-navigation__link"><a href="/internet-of-things/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things/videos">Videos</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things/webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things/whitepapers">Whitepapers</a></li>
         </ul>
       </div>
     </li>
@@ -39,6 +41,7 @@
           <li class="p-navigation__link"><a href="/desktop/case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/desktop/videos">Videos</a></li>
           <li class="p-navigation__link"><a href="/desktop/webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/desktop/whitepapers">Whitepapers</a></li>
         </ul>
       </div>
     </li>
@@ -67,6 +70,7 @@
         <li><a href="/cloud-and-server/case-studies">Case Studies</a></li>
         <li><a href="/cloud-and-server/videos">Videos</a></li>
         <li><a href="/cloud-and-server/webinars">Webinars</a></li>
+        <li><a href="/cloud-and-server/whitepapers">Whitepapers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">
@@ -77,6 +81,7 @@
         <li><a href="/internet-of-things/case-studies">Case Studies</a></li>
         <li><a href="/internet-of-things/videos">Videos</a></li>
         <li><a href="/internet-of-things/webinars">Webinars</a></li>
+        <li><a href="/internet-of-things/whitepapers">Whitepapers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">
@@ -87,6 +92,7 @@
         <li><a href="/desktop/case-studies">Case Studies</a></li>
         <li><a href="/desktop/videos">Videos</a></li>
         <li><a href="/desktop/webinars">Webinars</a></li>
+        <li><a href="/desktop/whitepapers">Whitepapers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -5,7 +5,7 @@
     <div class="col-12 u-align--right">
       <form action="" method="get" class="p-form p-form--inline">
         <div class="p-form__group">
-          <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
+          <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
           <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
             <option {% if category == 'all' %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}topics/{{ topic['slug'] }}{% endif %}">All content types</option>
             <option {% if category == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/articles">Articles</option>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,34 +1,36 @@
 {% block posts %}
 
 <div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-12 u-align--right">
-      <form action="" method="get" class="p-form p-form--inline">
-        <div class="p-form__group">
-          <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
-          <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
-            <option {% if category == 'all' %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}topics/{{ topic['slug'] }}{% endif %}">All content types</option>
-            <option {% if category == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/articles">Articles</option>
-            <option {% if category == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/case-studies">Case studies</option>
-            <option {% if category == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/videos">Videos</option>
-            <option {% if category == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/webinars">Webinars</option>
-            <option {% if category == 'whitepapers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/whitepapers">Whitepapers</option>
-          </select>
-          <input type="submit" value="Send Request" class="u-hide">
-          <input type="hidden" name="topic" value="cloud-and-server">
-        </div>
-      </form>
-      <script>
-      var select = document.querySelector('.js-submit-on-change');
-      select.addEventListener('change', function(e) {
-        var form = this.closest('form');
-        if (form) {
-          location.href=document.getElementById("filter").value;
-        }
-      });
-      </script>
+  {% if not topic %}
+    <div class="row">
+      <div class="col-12 u-align--right">
+        <form action="" method="get" class="p-form p-form--inline">
+          <div class="p-form__group">
+            <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
+            <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
+              <option {% if category == 'all' %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}">All content types</option>
+              <option {% if category == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/articles">Articles</option>
+              <option {% if category == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/case-studies">Case studies</option>
+              <option {% if category == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/videos">Videos</option>
+              <option {% if category == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/webinars">Webinars</option>
+              <option {% if category == 'whitepapers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{/whitepapers">Whitepapers</option>
+            </select>
+            <input type="submit" value="Send Request" class="u-hide">
+            <input type="hidden" name="topic" value="cloud-and-server">
+          </div>
+        </form>
+        <script>
+        var select = document.querySelector('.js-submit-on-change');
+        select.addEventListener('change', function(e) {
+          var form = this.closest('form');
+          if (form) {
+            location.href=document.getElementById("filter").value;
+          }
+        });
+        </script>
+      </div>
     </div>
-  </div>
+  {% endif %}
 
 {%- for post in posts %}
   {% if loop.index0 % 3 == 0 %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,6 +1,35 @@
 {% block posts %}
 
-<div class="p-strip">
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-12 u-align--right">
+      <form action="" method="get" class="p-form p-form--inline">
+        <div class="p-form__group">
+          <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
+          <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
+            <option {% if category == 'all' %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}topics/{{ topic['slug'] }}{% endif %}">All content types</option>
+            <option {% if category == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/articles">Articles</option>
+            <option {% if category == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/case-studies">Case studies</option>
+            <option {% if category == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/videos">Videos</option>
+            <option {% if category == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/webinars">Webinars</option>
+            <option {% if category == 'whitepapers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}{% if topic and topic['slug'] %}/topics/{{ topic['slug'] }}{% endif %}/whitepapers">Whitepapers</option>
+          </select>
+          <input type="submit" value="Send Request" class="u-hide">
+          <input type="hidden" name="topic" value="cloud-and-server">
+        </div>
+      </form>
+      <script>
+      var select = document.querySelector('.js-submit-on-change');
+      select.addEventListener('change', function(e) {
+        var form = this.closest('form');
+        if (form) {
+          location.href=document.getElementById("filter").value;
+        }
+      });
+      </script>
+    </div>
+  </div>
+
 {%- for post in posts %}
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">


### PR DESCRIPTION
## Done

- Moved filters from tab to dropdown
- Updated iot banner

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any page](http://0.0.0.0:8023)
- check tha the dropdown works for the homepage, group pages, topic pages
- see that there is no logo on the drone on the iot page

## Issue / Card

Fixes #183, https://github.com/ubuntudesign/web-squad/issues/361, https://github.com/ubuntudesign/web-squad/issues/362, https://github.com/ubuntudesign/web-squad/issues/359

Signed-off-by: Peter Mahnke <peter@transitionelement.com>