### PR TITLE
Make the press centre col-8 posts

### DIFF
--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -23,23 +23,19 @@
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
-        {%- for post in posts %} {% if loop.index0 % 2 == 0 %}
-        <div class="row u-equal-height u-clearfix">
-          {% endif %}
-          <div class="col-4 p-card--post">
-            <header class="p-card__header--{{ post.groups.slug }}">
-              <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
-            </header>
-            <div class="p-card__content">
-              <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
-              <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
-              <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
-            </div>
-            <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+        {%- for post in posts %}
+        <div class="p-card--post">
+          <header class="p-card__header--{{ post.groups.slug }}">
+            <h5 class="p-muted-heading">{{ post.groups.name }}</h5>
+          </header>
+          <div class="p-card__content">
+            <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
+            <p><em>By <a href="{{ post.author.relative_link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.formatted_date }}</em></p>
+            <p class="u-no-padding--bottom">{{ post.excerpt.rendered | striptags | urlize(30, true) }}</p>
           </div>
-          {% if loop.index0 % 2 == 1 or loop.last %}
+          <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
         </div>
-        {% endif %} {%- endfor %}
+        {%- endfor %}
       </div>
       <div class="col-4">
         <div class="p-card">


### PR DESCRIPTION
## Done
Change the layout of posts in the press center to a single column

## QA
- Go to the press-center
- See that the posts are in col-8 not in two columns