### PR TITLE
Sent current page to API to fix group archive pagination

### DIFF
--- a/app.py
+++ b/app.py
@@ -238,6 +238,7 @@ def archives_year_month(year, month):
 
 @app.route('/archives/<group>/<regex("[0-9]{4}"):year>')
 def archives_group_year(group, year):
+    page = flask.request.args.get('page')
     group_slug = group
 
     if group == 'press-centre':
@@ -251,7 +252,13 @@ def archives_group_year(group, year):
     group_id = int(groups['id']) if groups else None
     group_name = groups['name'] if groups else None
 
-    result, metadata = api.get_archives(year, None, group_id, group_name)
+    result, metadata = api.get_archives(
+        year,
+        None,
+        group_id,
+        group_name,
+        page=page
+    )
     return flask.render_template(
         'archives.html',
         result=result,


### PR DESCRIPTION
## Done

- Sent current page to API to fix group archive pagination

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a group page 2+ archive page](http://0.0.0.0:8023/archives/press-centre/2018?page=2)
- See that the correct page number is highlighted

## Issue / Card

Fixes #192

## Screenshots

![image](https://user-images.githubusercontent.com/441217/35827887-8cc1ef7c-0ab5-11e8-8f80-136018064789.png)
