### PR TITLE
Updated the canonical author icon and post header

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -4,12 +4,13 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object">
+        {# author.id 217 is Canonical, which needs the icon and description added manually #}
         <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">
             {{ author.name }}
           </h1>
-          <p class="p-media-object__content">{{ author.description | safe }}</p>
+          <p class="p-media-object__content">{% if author.id == 217 %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% else %}{{ author.description | safe }}{% endif %}</p>
         </div>
       </div>
     </div>

--- a/templates/author.html
+++ b/templates/author.html
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object">
-        <img src="{{ author.avatar_urls['96'] }}" class="p-media-object__image is-round">
+        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">
             {{ author.name }}

--- a/templates/post.html
+++ b/templates/post.html
@@ -23,6 +23,7 @@
     <div class="col-8">
       <div class="p-media-object">
         {% if post.author %}
+          {# post.author.id 217 is Canonical, which needs the icon added manually #}
           <img src="{% if post.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ post.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
         {% endif %}
         <div class="p-media-object__details">

--- a/templates/post.html
+++ b/templates/post.html
@@ -16,9 +16,14 @@
 <div class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
   <div class="row">
     <div class="col-10">
+      <h1>{{ post.title.rendered | safe }}</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-5">
       <div class="p-media-object">
         {% if post.author %}
-          <img src="{{ post.author.avatar_urls["96"] }}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
+          <img src="{% if post.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ post.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
         {% endif %}
         <div class="p-media-object__details">
           {% if post.author %}
@@ -30,27 +35,7 @@
         </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-10">
-      <h1>{{ post.title.rendered | safe }}</h1>
-    </div>
-  </div>
-  {% if tags %}
-  <div class="row">
-    <div class="col-10">
-      <p>
-        <strong>Tags:</strong>
-        {% for tag in tags %}
-          <a href="/tag/{{ tag.slug }}">
-            {{ tag.name }}</a>{{ ',' if not loop.last }}
-        {% endfor %}
-      </p>
-    </div>
-  </div>
-  {% endif %}
-  <div class="row">
-    <div class="col-10">
+    <div class="col-5">
       <ul class="p-inline-list u-vertically-center">
         <li class="p-inline-list__item">
           Share on:
@@ -78,6 +63,19 @@
       </ul>
     </div>
   </div>
+  {% if post.tags %}
+  <div class="row">
+    <div class="col-10">
+      <p>
+        <strong>Tags:</strong>
+        {% for tag in post.tags %}
+          <a href="/tag/{{ tag.slug }}">
+            {{ tag.name }}</a>{{ ',' if not loop.last }}
+        {% endfor %}
+      </p>
+    </div>
+  </div>
+  {% endif %}
 </div>
 <div class="p-strip is-shallow">
   <div class="row u-equal-height">

--- a/templates/post.html
+++ b/templates/post.html
@@ -15,12 +15,12 @@
 
 <div class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
   <div class="row">
-    <div class="col-10">
+    <div class="col-8">
       <h1>{{ post.title.rendered | safe }}</h1>
     </div>
   </div>
   <div class="row">
-    <div class="col-5">
+    <div class="col-8">
       <div class="p-media-object">
         {% if post.author %}
           <img src="{% if post.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ post.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
@@ -35,7 +35,7 @@
         </div>
       </div>
     </div>
-    <div class="col-5">
+    <div class="col-4">
       <ul class="p-inline-list u-vertically-center">
         <li class="p-inline-list__item">
           Share on:
@@ -63,18 +63,18 @@
       </ul>
     </div>
   </div>
-  {% if post.tags %}
-  <div class="row">
-    <div class="col-10">
-      <p>
-        <strong>Tags:</strong>
-        {% for tag in post.tags %}
-          <a href="/tag/{{ tag.slug }}">
-            {{ tag.name }}</a>{{ ',' if not loop.last }}
-        {% endfor %}
-      </p>
+  {% if tags %}
+    <div class="row">
+      <div class="col-10">
+        <p>
+          <strong>Tags:</strong>
+          {% for tag in tags %}
+            <a href="/tag/{{ tag.slug }}">
+              {{ tag.name }}</a>{{ ',' if not loop.last }}
+          {% endfor %}
+        </p>
+      </div>
     </div>
-  </div>
   {% endif %}
 </div>
 <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done

- Updated the canonical author icon and post header per Spencer’s recommendation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a post](http://0.0.0.0:8023/2018/01/30/ubuntu-server-development-summary-30-jan-2018) and the [Canonical author page](http://0.0.0.0:8023/author/canonical)
- See that you get the Canonical logo and that the post header is smaller.

## Screenshots

![image](https://user-images.githubusercontent.com/441217/35872545-0411cf26-0b5f-11e8-8b99-9fe30d2500af.png)
