### PR TITLE
Replace category pages (/articles) with a filterable homepage (/?category=articles)

### DIFF
--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -11,11 +11,11 @@
       <div class="p-accordion__panel" id="cloud" role="tabpanel" aria-hidden="true" aria-labelledby="cloud-tab">
         <ul class="p-navigation__links">
           <li class="p-navigation__link"><a href="/cloud-and-server">All</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server/articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server/case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server/videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server/webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server/white-papers">White papers</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server?category=articles">Articles</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server?category=case-studies">Case Studies</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server?category=videos">Videos</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server?category=webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/cloud-and-server?category=white-papers">White papers</a></li>
         </ul>
       </div>
     </li>
@@ -24,11 +24,11 @@
       <div class="p-accordion__panel" id="iot" role="tabpanel" aria-hidden="true" aria-labelledby="iot-tab">
         <ul class="p-navigation__links">
           <li class="p-navigation__link"><a href="/internet-of-things">All</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things/articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things/case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things/videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things/webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things/white-papers">White papers</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things?category=articles">Articles</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things?category=videos">Videos</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things?category=webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/internet-of-things?category=white-papers">White papers</a></li>
         </ul>
       </div>
     </li>
@@ -37,11 +37,11 @@
       <div class="p-accordion__panel" id="desktop" role="tabpanel" aria-hidden="true" aria-labelledby="desktop-tab">
         <ul class="p-navigation__links">
           <li class="p-navigation__link"><a href="/desktop">All</a></li>
-          <li class="p-navigation__link"><a href="/desktop/articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/desktop/case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/desktop/videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/desktop/webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/desktop/white-papers">White papers</a></li>
+          <li class="p-navigation__link"><a href="/desktop?category=articles">Articles</a></li>
+          <li class="p-navigation__link"><a href="/desktop?category=case-studies">Case Studies</a></li>
+          <li class="p-navigation__link"><a href="/desktop?category=videos">Videos</a></li>
+          <li class="p-navigation__link"><a href="/desktop?category=webinars">Webinars</a></li>
+          <li class="p-navigation__link"><a href="/desktop?category=white-papers">White papers</a></li>
         </ul>
       </div>
     </li>
@@ -66,33 +66,33 @@
       <a href="/cloud-and-server">Cloud and Server</a>
       <ul class="hover-menu">
         <li><a href="/cloud-and-server">All</a></li>
-        <li><a href="/cloud-and-server/articles">Articles</a></li>
-        <li><a href="/cloud-and-server/case-studies">Case Studies</a></li>
-        <li><a href="/cloud-and-server/videos">Videos</a></li>
-        <li><a href="/cloud-and-server/webinars">Webinars</a></li>
-        <li><a href="/cloud-and-server/white-papers">White papers</a></li>
+        <li><a href="/cloud-and-server?category=articles">Articles</a></li>
+        <li><a href="/cloud-and-server?category=case-studies">Case Studies</a></li>
+        <li><a href="/cloud-and-server?category=videos">Videos</a></li>
+        <li><a href="/cloud-and-server?category=webinars">Webinars</a></li>
+        <li><a href="/cloud-and-server?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">
       <a href="/internet-of-things">IoT</a>
       <ul class="hover-menu">
         <li><a href="/internet-of-things">All</a></li>
-        <li><a href="/internet-of-things/articles">Articles</a></li>
-        <li><a href="/internet-of-things/case-studies">Case Studies</a></li>
-        <li><a href="/internet-of-things/videos">Videos</a></li>
-        <li><a href="/internet-of-things/webinars">Webinars</a></li>
-        <li><a href="/internet-of-things/white-papers">White papers</a></li>
+        <li><a href="/internet-of-things?category=articles">Articles</a></li>
+        <li><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
+        <li><a href="/internet-of-things?category=videos">Videos</a></li>
+        <li><a href="/internet-of-things?category=webinars">Webinars</a></li>
+        <li><a href="/internet-of-things?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">
       <a href="/desktop">Desktop</a>
       <ul class="hover-menu">
         <li><a href="/desktop">All</a></li>
-        <li><a href="/desktop/articles">Articles</a></li>
-        <li><a href="/desktop/case-studies">Case Studies</a></li>
-        <li><a href="/desktop/videos">Videos</a></li>
-        <li><a href="/desktop/webinars">Webinars</a></li>
-        <li><a href="/desktop/white-papers">White papers</a></li>
+        <li><a href="/desktop?category=articles">Articles</a></li>
+        <li><a href="/desktop?category=case-studies">Case Studies</a></li>
+        <li><a href="/desktop?category=videos">Videos</a></li>
+        <li><a href="/desktop?category=webinars">Webinars</a></li>
+        <li><a href="/desktop?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link">

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,7 +1,7 @@
 <section class="p-strip is-shallow is-bordered u-no-padding--top">
   <div class="row">
     <div class="col-12">
-      {% if current_page and total_pages %}
+      {% if current_page and total_pages and total_pages > 1 %}
         <ul class="p-inline-list--middot u-align--center" style="margin-bottom: 1rem;">
           {% if current_page > 1 %}
             <li class="p-inline-list__item"><a href="{{request.path}}?page={{ current_page - 1 }}">Previous</a></li>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,19 +1,19 @@
 {% block posts %}
 
-<div class="p-strip is-shallow">
-  {% if not topic %}
+<div class="p-strip is-shallow" id="posts-list">
+  {% if not tag %}
     <div class="row">
       <div class="col-12 u-align--right">
         <form action="" method="get" class="p-form p-form--inline">
           <div class="p-form__group">
             <label for="filter" aria-label="Filter the resources by type" class="p-form__label">Filter: </label>
             <select class="js-submit-on-change p-form__control" id="filter" name="content" aria-label="Filter by content type" style="padding-right: 40px">
-              <option {% if not category %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}">All content types</option>
-              <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/articles">Articles</option>
-              <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/case-studies">Case studies</option>
-              <option {% if category and category.slug == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/videos">Videos</option>
-              <option {% if category and category.slug == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/webinars">Webinars</option>
-              <option {% if category and category.slug == 'white-papers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}/white-papers">White papers</option>
+              <option {% if not category %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}#posts-list">All content types</option>
+              <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=articles#posts-list">Articles</option>
+              <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=case-studies#posts-list">Case studies</option>
+              <option {% if category and category.slug == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=videos#posts-list">Videos</option>
+              <option {% if category and category.slug == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=webinars#posts-list">Webinars</option>
+              <option {% if category and category.slug == 'white-papers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=white-papers#posts-list">White papers</option>
             </select>
             <input type="submit" value="Send Request" class="u-hide">
             <input type="hidden" name="topic" value="cloud-and-server">

--- a/tests.py
+++ b/tests.py
@@ -13,12 +13,12 @@ test_content = 'Ubuntu and Canonical are registered'
 
 working_uris = [
     '/',  # Homepage
+    '/?category=articles',  # Category filter on homepage
     '/cloud-and-server?page=2',  # Group page
     '/cloud-and-server?page=999',  # Group empty page
-    '/cloud-and-server/white-papers',  # whitepapers page
-    '/cloud-and-server/case-studies?page=2',  # Group & category page
-    '/cloud-and-server/case-studies?page=999',  # Group & category empty page
-    '/articles',  # Category page
+    '/cloud-and-server?category=white-papers',  # whitepapers page
+    '/cloud-and-server?category=case-studies&page=2',  # Group & category page
+    '/cloud-and-server?category=case-studies&page=999',  # empty page
     '/press-centre',  # Press centre
     '/topics/maas?page=2',  # Topic page
     '/topics/maas?page=999',  # Topic empty page
@@ -161,7 +161,7 @@ class WebAppTestCase(unittest.TestCase):
         slashes, returns a 200 and contains the standard footer text
         """
 
-        if uri == '/':
+        if urlparse(uri).path == '/':
             response = self._get_check_cache(uri)
         else:
             response = self._get_check_slash_normalisation(uri)


### PR DESCRIPTION
**Based on #202 - review that first**

- Remove e.g. `/article` routes in favour of `/?category=article`
- Remove e.g. `/cloud-and-server/article` routes in favour of `/cloud-and-server?category=article`
- Remove filter menu from tag pages (it didn't work anyway)
- Make pagination only show up if there's more than 1 page
- Filtering on homepage now leaves you on homepage, but filtered
- Clicking on filter menu now jumps you down to the posts section. This is so that on homepage you don't get confused at all the content that may be above the posts

QA
--

`./run`, thoroughly check homepage filtering and group pages filtering. Check also tag and topic pages.