### PR TITLE
Fix articles without an author

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -72,8 +72,11 @@ def format_post(post):
     - Making the link relative
     """
 
-    post['author'] = post['_embedded']['author'][0]
-    post['author']['link'] = urlsplit(post['author']['link']).path.rstrip('/')
+    if 'author' in post['_embedded'] and post['_embedded']['author']:
+        post['author'] = post['_embedded']['author'][0]
+        post['author']['link'] = urlsplit(
+            post['author']['link']
+        ).path.rstrip('/')
     post['link'] = urlsplit(post['link']).path.rstrip('/')
     post['summary'] = format_summary(post['excerpt']['rendered'])
     post['date'] = format_date(post['date'])

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -20,7 +20,9 @@
                 <a href="{{ post.link }}">{{ post.title.rendered | safe }}</a>
               </h3>
               <div class="p-media-object__content">
-                <p>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.date }}</p>
+                {% if post.author %}
+                  <p>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.date }}</p>
+                {% endif %}
                 <p>{{ post.summary | striptags | urlize(30, true) }}</p>
               </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,9 @@
     <div class="col-8">
       <h3 class="p-heading--four">Featured article</h3>
       <h2 class="p-heading--three"><a href="{{ featured_post.link }}">{{ featured_post.title.rendered | safe }}</a></h2>
-      <p><em>By <a href="{{ featured_post.author.link }}" title="More about {{ featured_post.author.name }}">{{ featured_post.author.name }}</a> on {{ featured_post.date }}</em></p>
+      {% if featured_post.author %}
+        <p><em>By <a href="{{ featured_post.author.link }}" title="More about {{ featured_post.author.name }}">{{ featured_post.author.name }}</a> on {{ featured_post.date }}</em></p>
+      {% endif %}
       <p class="u-no-padding--bottom">{{ featured_post.summary | striptags | urlize(30, true) }}</p>
     </div>
   </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -17,11 +17,15 @@
   <div class="row">
     <div class="col-10">
       <div class="p-media-object">
-        <img src="{{ post.author.avatar_urls["96"] }}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
+        {% if post.author %}
+          <img src="{{ post.author.avatar_urls["96"] }}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
+        {% endif %}
         <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>
-          </h3>
+          {% if post.author %}
+            <h3 class="p-media-object__title">
+              <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>
+            </h3>
+          {% endif %}
           <p class="p-media-object__content">on {{ post.date }}</p>
         </div>
       </div>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -42,7 +42,9 @@
       </header>
       <div class="p-card__content">
         <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
-        <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
+        {% if post.author %}
+          <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
+        {% endif %}
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
       </div>
       <p class="p-card__footer">{{ post.category.name | capitalize }}</p>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -30,7 +30,9 @@
           </header>
           <div class="p-card__content">
             <h3 class="p-heading--four"><a href="{{ post.relative_link }}">{{ post.title.rendered | safe }}</a></h3>
-            <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
+            {% if post.author %}
+              <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
+            {% endif %}
             <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
           </div>
           <p class="p-card__footer">{{ post.category.name | capitalize }}</p>

--- a/templates/search.html
+++ b/templates/search.html
@@ -31,7 +31,9 @@
           <li class="p-list__item">
             <p style="padding-top: 1.5rem;">
               <span class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></span><br />
-              <small>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.date }}</small><br />
+              {% if post.author %}
+                <small>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a>, {{ post.date }}</small><br />
+              {% endif %}
               {{ post.summary | striptags | urlize(30, true) }}</p>
           </li>
           {% endfor %}

--- a/tests.py
+++ b/tests.py
@@ -35,6 +35,7 @@ working_uris = [
     '/archives?year=2099&month=12',  # Empty archive month
     '/archives?group=cloud-and-server&year=2099&page=2',  # Empty group archive
     '/2018/01/24/meltdown-spectre-and-ubuntu-what-you-need-to-know',  # article
+    '/2017/08/31/openstack-weekly-update-august-31-2017',  # article no author
 ]
 
 missing_uris = [


### PR DESCRIPTION
**Based on #202 - review that first**

Fixes #185

QA
--

`./run` and go to:

- http://0.0.0.0:8023/search?q=lxd&page=5 and see "OpenStack Weekly Update" displays without an author
- http://0.0.0.0:8023/cloud-and-server?page=15 and see that "Weekly Kernel Development Summary – Wed July 27, 2017" displays without an author
- http://0.0.0.0:8023/2017/08/31/openstack-weekly-update-august-31-2017 displays with no author