### PR TITLE
Stop checking cache on every request in tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -118,6 +118,7 @@ class WebAppTestCase(unittest.TestCase):
             assert test_content in str(response.data)
             print('done')
 
+    @ignore_warnings(ResourceWarning)
     def _get_check_slash_normalisation(self, uri):
         """
         Given a basic app path (e.g. '/page'), check that any trailing
@@ -134,27 +135,9 @@ class WebAppTestCase(unittest.TestCase):
         url = "http://localhost" + uri
         assert redirect_response.headers.get('Location') == url
 
-        return self._get_check_cache(url)
+        return self.app.get(uri)
 
     @ignore_warnings(ResourceWarning)
-    def _get_check_cache(self, uri):
-        """
-        Retrieve URL contents twice - checking the second response is cached
-        """
-
-        # Warm cache
-        initial_response = self.app.get(uri)
-
-        # Make a request with the cache warmed
-        start = time.time()
-        subsequent_response = self.app.get(uri)
-        request_time = time.time() - start
-
-        assert initial_response.data == subsequent_response.data
-        assert request_time < 1
-
-        return subsequent_response
-
     def _check_basic_page(self, uri):
         """
         Check that a URI returns an HTML page that will redirect to remove
@@ -162,7 +145,7 @@ class WebAppTestCase(unittest.TestCase):
         """
 
         if urlparse(uri).path == '/':
-            response = self._get_check_cache(uri)
+            response = self.app.get(uri)
         else:
             response = self._get_check_slash_normalisation(uri)
 


### PR DESCRIPTION
**Based on #202 - review that first**

This will make tests much more reliable, not dependent on the individual internet connection.

QA
--

`./run test`, check tests pass. And that travis tests pass.