### PR TITLE
Update the IoT blurb

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -9,7 +9,7 @@
     {
         "name": "Internet of Things",
         "slug": "internet-of-things",
-        "description": "A new, snappy, transactionally updated Ubuntu for clouds and devices.",
+        "description": "All you need to know about building and managing IoT and embedded devices using Ubuntu.",
         "url": "https://www.ubuntu.com/things",
         "hero_url": "https://assets.ubuntu.com/v1/d1d58769-drone-iceland-unsplash-no-logo.jpg"
     },


### PR DESCRIPTION
## Done
Updated the IoT group page into to "All you need to know about building and managing IoT and embedded devices using Ubuntu."

## QA
- Go to IoT group page
- Check the intro text matches the above