### PR TITLE
Filter archives by category

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,12 +239,14 @@ def archives():
     year = helpers.to_int(flask.request.args.get('year'))
     month = helpers.to_int(flask.request.args.get('month'))
     group_slug = flask.request.args.get('group')
+    category_slug = flask.request.args.get('category')
 
     if month and month > 12:
         month = None
 
     friendly_date = None
     group = None
+    category = None
     after = None
     before = None
 
@@ -264,17 +266,25 @@ def archives():
         if groups:
             group = groups[0]
 
+    if category_slug:
+        categories = api.get_categories(slugs=[category_slug])
+
+        if categories:
+            category = categories[0]
+
     posts, total_posts, total_pages = helpers.get_formatted_posts(
         page=page,
         after=after,
         before=before,
         group_ids=[group['id']] if group else [],
+        category_ids=[category['id']] if category else [],
     )
 
     return flask.render_template(
         'archives.html',
         posts=posts,
         group=group,
+        category=category,
         current_page=page,
         total_posts=total_posts,
         total_pages=total_pages,

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -4,8 +4,18 @@
   <section id="main-content" class="p-strip--accent is-dark is-deep">
     <div class="row">
       <div class="col-10">
-        <h1>{{ group.name + ' archives' if group else 'Archives' }}</h1>
-        <p>{{ total_posts }} posts{{ ' from ' + friendly_date if friendly_date }}</p>
+        <h1>
+          {% if group %}
+            {{ group.name }} archives
+          {% else %}
+            Archives
+          {% endif %}
+        </h1>
+        <p>
+          {{ total_posts }}
+          {{ category.name | lower if category else 'posts' }}
+          {{ ' from ' + friendly_date if friendly_date }}
+        </p>
       </div>
     </div>
   </section>
@@ -34,13 +44,13 @@
 
         <ul class="p-list">
           {% for year in range(now.year, 2006, -1) %}
-            <li class="p-list__item"><h5><a class="p-link--soft" href="/archives?year={{ year }}{{ '&group=' + group.slug if group }}">{{ year }}</a></h5>
+            <li class="p-list__item"><h5><a class="p-link--soft" href="/archives?year={{ year }}{{ '&group=' + group.slug if group }}{{ '&category=' + category.slug if category }}">{{ year }}</a></h5>
             {% if not group %}
               <ul class="p-inline-list--middot">
                 {% for month in range(1, 13, 1) %}
                   {# need to skip months in the current year that haven't occured #}
                   {% if now.year != year or (now.year == year and month <= now.month) %}
-                    <li class="p-inline-list__item"><a class="p-link--soft" href="/archives?year={{ year }}&amp;month={{ month }}">{{ month | monthname }}</a></li>
+                    <li class="p-inline-list__item"><a class="p-link--soft" href="/archives?year={{ year }}&amp;month={{ month }}{{ '&category=' + category.slug if category }}">{{ month | monthname }}</a></li>
                   {% endif %}
                 {% endfor %}
               </li>


### PR DESCRIPTION
This isn't currently used in the site's IA, but it seems like it makes
sense as a feature of the archives section. It also allows us the ability
to forward some old links that existed on the old site somewhere (e.g.
https://insights.ubuntu.com/group/phone-and-tablet?cat=1453)

QA
--

`./run`

Go to http://0.0.0.0:8023/archives?group=cloud-and-server&category=case-studies or http://0.0.0.0:8023/archives?category=case-studies or http://0.0.0.0:8023/archives?group=cloud-and-server. Click around, try filtering by year etc.