### PR TITLE
171: Fix sign-up form positioning

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -100,22 +100,6 @@ pre {
   }
 }
 
-.p-heading-icon__title {
-  font-size: 2.5rem;
-}
-
-.card-image {
-  box-shadow: 0 1px 5px 1px rgba(51, 51, 51, 0.2);
-  margin-top: 1.5rem !important;
-  max-height: 100%;
-}
-
-@media (min-width: $breakpoint-medium + 1) {
-  .card-image {
-    margin-top: 2.5rem !important;
-  }
-}
-
 .design-image {
   padding-top: 1.5rem;
   max-height: 100%;
@@ -127,11 +111,6 @@ pre {
   }
 }
 
-.group-image {
-  max-height: 240px;
-  padding-top: $sp-medium;
-}
-
 .header-strip {
   height: inherit;
 }
@@ -140,18 +119,6 @@ pre {
   .header-strip {
     height: 320px;
   }
-}
-
-.u-position--bottom {
-  @media (min-width: $breakpoint-medium) {
-    bottom: 0;
-    position: absolute;
-  }
-}
-
-  /// XXX remove whitespace under footer
-.p-footer {
-  padding-bottom: 2.5rem;
 }
 
 // XXX Caleb - 30.01.18 Nav search box styling fixes
@@ -180,15 +147,6 @@ pre {
 
   @media (min-width: $breakpoint-medium) {
     height: 3.5rem;
-  }
-}
-
-// XXX Caleb - Tabs padding fixes
-.p-tabs__list {
-  padding: 0;
-
-  @media (min-width: $breakpoint-medium) {
-    padding: 0;
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -191,3 +191,9 @@ pre {
     padding: 0;
   }
 }
+
+.right-rail {
+  display: flex !important;
+  flex-direction: column;
+  justify-content: space-between;
+}

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -1,4 +1,4 @@
-<div class="p-card u-position--bottom">
+<div class="p-card">
   <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
     <h3 class="p-card--title p-heading--four">Sign up for email updates</h3>
     <div class="p-card--content">

--- a/templates/post.html
+++ b/templates/post.html
@@ -83,7 +83,7 @@
     <div class="col-8">
       {{ post.content.rendered | safe }}
     </div>
-    <div class="col-4">
+    <div class="col-4 right-rail">
       {# right rail #}
       {% include 'product-cards.html' %}
       {% include 'newsletter-form.html' %}

--- a/templates/topics/design.html
+++ b/templates/topics/design.html
@@ -7,7 +7,7 @@
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt=""/>
-            <h1 class="p-heading--one p-heading-icon__title">Design</h1>
+            <h1 class="p-heading--one u-no-margin--top">Design</h1>
           </div>
           <h2 class="p-heading--two">Branding and web development</h2>
           <p class="p-heading--five">All the latest news on the design team at Canonical.</p>


### PR DESCRIPTION
# Done
- Fixed a bug where signup form would overlap header if there was only a small amount of content in the post
- Removed a few unused styles

# QA
- `./run`
- Navigate to http://0.0.0.0:8023/2017/12/02/building-21st-century-infrastructure
- Check that the sign-up form remains below the rtp cloud card
- Check a few other posts and make sure it still looks right

# Issues
Fixes #171 
