### PR TITLE
Made canonical-announcemnts archives only go to 2015

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -43,7 +43,11 @@
         <h3>Archives</h3>
 
         <ul class="p-list">
-          {% for year in range(now.year, 2006, -1) %}
+          {% set endyear = 2006 %}
+          {% if group.slug  == 'canonical-announcements' %}
+            {% set endyear = 2015 %}
+          {% endif %}
+          {% for year in range(now.year, endyear, -1) %}
             <li class="p-list__item"><h5><a class="p-link--soft" href="/archives?year={{ year }}{{ '&group=' + group.slug if group }}{{ '&category=' + category.slug if category }}">{{ year }}</a></h5>
             {% if not group %}
               <ul class="p-inline-list--middot">

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -68,7 +68,7 @@
         <div class="p-card">
           <h4>Archives</h4>
           <ul class="p-list">
-            {% for year in range(current_year, 2005, -1) %}
+            {% for year in range(current_year, 2015, -1) %}
               <li class="p-list__item"><h5><a class="p-link--soft" href="/archives?group=canonical-announcements&amp;year={{ year }}">{{ year }}</a></h5></li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
## Done

- Made canonical-announcemnts archives only go to 2015

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
 - [press centre page](http://0.0.0.0:8023/press-centre)
 - [press centre archive page](http://0.0.0.0:8023/archives?group=canonical-announcements&year=2016)
- see that the archive right rail list only goes back to 2016 and see that it is long er on other [archive pages](http://0.0.0.0:8023/archives?group=cloud-and-server&year=2016)

## Issue / Card

Fixes #219

## Screenshots

![image](https://user-images.githubusercontent.com/441217/36030693-1b8ecf12-0da0-11e8-8457-23d1104956ad.png)
