### PR TITLE
Add a simple endpoint to test the app is healthy

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,18 @@ def clear_trailing():
         return flask.redirect(new_uri)
 
 
+@app.route('/status')
+def status():
+    """
+    A simple response to test that the app is alive and working.
+    This can be targeted by Kubernetes readiness and liveness checks.
+    As used in snapcraft.io:
+    https://github.com/canonical-websites/snapcraft.io/pull/327/files
+    """
+
+    return 'alive'
+
+
 @app.route('/')
 def homepage():
     category_slug = flask.request.args.get('category')


### PR DESCRIPTION
This can be targeted by Kubernetes liveness and readiness checks.

Copied from snapcraft.io:
https://github.com/canonical-websites/snapcraft.io/pull/327/files

QA
--

We need to test `/status` works even without any API cache.

``` bash
./run build  # Make sure dependencies are installed
```

Now disconnect from the internet

``` bash
rm -f cache.sqlite  # Remove cache
./run            # Run site
```

Go to http://0.0.0.0:8023/status, see "alive".

Now you may have your internet back.