### PR TITLE
Log output docker to stdout and stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ ADD . .
 RUN pip3 install -r requirements.txt
 
 # Setup commands to run server
-ENTRYPOINT ["gunicorn", "app:app", "-b"]
+ENTRYPOINT ["gunicorn", "app:app", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
 CMD ["0.0.0.0:80"]


### PR DESCRIPTION
This is so that the logs in Kubernetes show something useful.

QA
--

``` bash
$ docker build . --build-arg COMMIT_ID=`git rev-parse HEAD` --tag insights
$ docker run -p 8023:80 insights
[2018-02-27 12:27:57 +0000] [1] [INFO] Starting gunicorn 19.7.1
[2018-02-27 12:27:57 +0000] [1] [INFO] Listening at: http://0.0.0.0:80 (1)
[2018-02-27 12:27:57 +0000] [1] [INFO] Using worker: sync
[2018-02-27 12:27:57 +0000] [9] [INFO] Booting worker with pid: 9
```

Check you see the output of the server starting ^. Now browse around a bit. Check you see the requests appear in the output, e.g.:

```
172.17.0.1 - - [27/Feb/2018:12:28:13 +0000] "GET / HTTP/1.1" 200 64968 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.108 Safari/537.36"
[2018-02-27 12:28:30 +0000] [1] [INFO] Handling signal: winch
172.17.0.1 - - [27/Feb/2018:12:28:36 +0000] "GET /internet-of-things HTTP/1.1" 200 31280 "http://localhost:8023/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.108 Safari/537.36"
```