### PR TITLE
Include query string in redirects

### DIFF
--- a/redirects.py
+++ b/redirects.py
@@ -50,7 +50,15 @@ class YamlRegexMap:
                 parts = {}
                 for name, value in result.groupdict().items():
                     parts[name] = value or ''
-                return target.format(**parts)
+
+                target_url = target.format(**parts)
+
+                if flask.request.query_string:
+                    target_url += (
+                        '?' + flask.request.query_string.decode('utf-8')
+                    )
+
+                return target_url
 
 
 def prepare_redirects(


### PR DESCRIPTION
QA
--

``` bash
./run
```

Then in a new window

``` bash
$ curl -sI 'http://0.0.0.0:8023/wp-json/wp/v2/posts?_embed&categories=1172,1509,1187,1485&per_page=10&offset=0' | grep Location
curl -sI 'http://0.0.0.0:8023/wp-json/wp/v2/posts?_embed&categories=1172,1509,1187,1485&per_page=10&offset=0' | grep Location
```

^ Includes query string!

``` bash
$ curl -sI 'http://0.0.0.0:8023/wp-json/wp/v2/posts' | grep Location
curl -sI 'http://0.0.0.0:8023/wp-json/wp/v2/posts' | grep Location
```

^ Doesn't!