### PR TITLE
If displaying a post, add post title to page title

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ubuntu Insights {% block title %}{% endblock %}</title>
+    <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Ubuntu Insights</title>
 
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />

--- a/templates/post.html
+++ b/templates/post.html
@@ -16,7 +16,7 @@
 <div class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
   <div class="row">
     <div class="col-8">
-      <h1>{{ post.title.rendered | safe }}</h1>
+      <h1>{% block title %}{{ post.title.rendered | safe }}{% endblock %}</h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
This brings back the previous way of rendering post titles in the page title, using the "\<post title\> | Ubuntu Insights" format. This would help with GA tracking of page titles and certainly avoid an SEO regression.

If the page doesn't contain a `title` block, the page title falls back to "Ubuntu Insights"

## QA

1. Ensure posts have the blog title in the page title
2. Ensure other pages fallback to "Ubuntu Insights"