### PR TITLE
Filter on sticky properly

### DIFF
--- a/api.py
+++ b/api.py
@@ -69,6 +69,7 @@ def get_posts(
                 'per_page': per_page,
                 'page': page,
                 'search': query,
+                'sticky': sticky,
                 'slug': ','.join(slugs),
                 'group': helpers.join_ids(group_ids),
                 'categories': helpers.join_ids(category_ids),


### PR DESCRIPTION
Fixes #244

QA
--

`./run`

Check you see "Canonical announces Ubuntu Core across Rigado’s IoT gateways" rather than "Your first robot: The driver [4/5]".