### PR TITLE
Fix extra long headings in posts

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -167,3 +167,7 @@ pre {
     border-bottom-color: $color-mid-dark;
   }
 }
+
+.p-post__content {
+  max-width: 35em;
+}

--- a/templates/post.html
+++ b/templates/post.html
@@ -81,7 +81,9 @@
 <div class="p-strip is-shallow">
   <div class="row u-equal-height">
     <div class="col-8">
-      {{ post.content.rendered | safe }}
+      <div class="p-post__content">
+        {{ post.content.rendered | safe }}
+      </div>
     </div>
     <div class="col-4 right-rail">
       {# right rail #}


### PR DESCRIPTION
Fixes issue where headings wrap at a longer measure than paragraphs

[Fixes #240](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/240)