### PR TITLE
Replace press centre photo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+[please describe the issue]
+
+## Process
+
+[list the steps to replicate the issue]
+
+## Current and expected result
+
+[describe what happened and what you expected]
+
+## Screenshot
+
+[if relevant, include a screenshot]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Done
+
+[List of work items including drive-bys]
+
+## QA
+
+- Check out this feature branch
+- Run the site using the command `./run serve`
+- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
+- [List additional steps to QA the new features or prove the bug has been resolved]
+
+
+## Issue / Card
+
+[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]
+
+## Screenshots
+
+[if relevant, include a screenshot]

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block body %}
 
-  <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/f7fc5efe-image-partners.jpg')">
+  <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/dc337e68-image-partners.jpg')">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6 p-card--suru">
         <h1 class="p-heading--one">Press centre</h1>


### PR DESCRIPTION
## Done
- Replace main image on press centre page
- Add github issue and pull request templates to repo

## QA
- Check out this feature branch (`241-change-press-centre-photo`)
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/press-centre](http://0.0.0.0:8023/press-centre)
- Check that main image doesn't have Lenovo logo


## Issue / Card
[Fixes #241](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/241)

## Screenshots

![ubuntu insights](https://user-images.githubusercontent.com/501889/37455919-261691bc-2836-11e8-9cae-408512f535d3.jpg)

