### PR TITLE
Add pagination to homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,6 +144,8 @@ def homepage():
     category = None
     sticky_posts, _, _ = helpers.get_formatted_expanded_posts(sticky=True)
     featured_post = sticky_posts[0] if sticky_posts else None
+    page = helpers.to_int(flask.request.args.get('page'), default=1)
+    posts_per_page = 13 if page == 1 else 12
 
     if category_slug:
         categories = api.get_categories(slugs=[category_slug])
@@ -152,8 +154,9 @@ def homepage():
             category = categories[0]
 
     posts, total_posts, total_pages = helpers.get_formatted_expanded_posts(
-        per_page=13,
-        category_ids=[category['id']] if category else []
+        per_page=posts_per_page,
+        category_ids=[category['id']] if category else [],
+        page=page
     )
 
     if featured_post and featured_post in posts:
@@ -161,8 +164,11 @@ def homepage():
 
     return flask.render_template(
         'index.html',
-        posts=posts[:12],
+        posts=posts,
         category=category,
+        current_page=page,
+        total_posts=total_posts,
+        total_pages=total_pages,
         featured_post=featured_post,
         webinars=feeds.get_rss_feed_content(
             'https://www.brighttalk.com/channel/6793/feed'

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,6 +104,8 @@
 
   {% include "posts.html" %}
 
+  {% include "pagination.html" %}
+
 <div class="p-strip is-bordered">
   <div class="row">
     <h2>Webinars</h2>

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -51,7 +51,7 @@
           {% endif %}
 
           {% if total_pages > current_page %}
-            <li class="p-inline-list__item"><a href="{{ page_prefix }}{{ current_page - 1 }}">Next</a></li>
+            <li class="p-inline-list__item"><a href="{{ page_prefix }}{{ current_page + 1 }}">Next</a></li>
           {% endif %}
         </ul>
       {% endif %}


### PR DESCRIPTION
## Done
- Add pagination to homepage beneath posts

## QA
- Check out this feature branch (`238-add-pagination-to-homepage`)
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023](http://0.0.0.0:8023)
- Check that pagination appears beneath posts and above webinars


## Issue / Card
[Fixes #238](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/238)

## Screenshots
![ubuntu insights](https://user-images.githubusercontent.com/501889/37469659-b0b08e00-285d-11e8-91d0-cfde0bc689b9.jpg)
