### PR TITLE
Remove empty categories from IoT and desktop pages

### DIFF
--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -26,9 +26,7 @@
           <li class="p-navigation__link"><a href="/internet-of-things">All</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things?category=articles">Articles</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=videos">Videos</a></li>
           <li class="p-navigation__link"><a href="/internet-of-things?category=webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=white-papers">White papers</a></li>
         </ul>
       </div>
     </li>
@@ -40,7 +38,6 @@
           <li class="p-navigation__link"><a href="/desktop?category=articles">Articles</a></li>
           <li class="p-navigation__link"><a href="/desktop?category=case-studies">Case Studies</a></li>
           <li class="p-navigation__link"><a href="/desktop?category=videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=webinars">Webinars</a></li>
           <li class="p-navigation__link"><a href="/desktop?category=white-papers">White papers</a></li>
         </ul>
       </div>
@@ -79,9 +76,7 @@
         <li><a href="/internet-of-things">All</a></li>
         <li><a href="/internet-of-things?category=articles">Articles</a></li>
         <li><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
-        <li><a href="/internet-of-things?category=videos">Videos</a></li>
         <li><a href="/internet-of-things?category=webinars">Webinars</a></li>
-        <li><a href="/internet-of-things?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'desktop' %} is-selected{% endif %}">
@@ -91,7 +86,6 @@
         <li><a href="/desktop?category=articles">Articles</a></li>
         <li><a href="/desktop?category=case-studies">Case Studies</a></li>
         <li><a href="/desktop?category=videos">Videos</a></li>
-        <li><a href="/desktop?category=webinars">Webinars</a></li>
         <li><a href="/desktop?category=white-papers">White papers</a></li>
       </ul>
     </li>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -11,9 +11,15 @@
               <option {% if not category %}selected="selected"{% endif %} value="/{% if group_details and group_details['slug'] %}{{ group_details['slug'] }}{% endif %}#posts-list">All content types</option>
               <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=articles#posts-list">Articles</option>
               <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=case-studies#posts-list">Case studies</option>
+              {% if request.path != '/internet-of-things' %}
               <option {% if category and category.slug == 'videos' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=videos#posts-list">Videos</option>
+              {% endif %}
+              {% if request.path != '/desktop' %}
               <option {% if category and category.slug == 'webinars' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=webinars#posts-list">Webinars</option>
+              {% endif %}
+              {% if request.path != '/internet-of-things' %}
               <option {% if category and category.slug == 'white-papers' %}selected="selected"{% endif %} value="{% if group_details and group_details['slug'] %}/{{ group_details['slug'] }}{% endif %}?category=white-papers#posts-list">White papers</option>
+              {% endif %}
             </select>
             <input type="submit" value="Send Request" class="u-hide">
             <input type="hidden" name="topic" value="cloud-and-server">


### PR DESCRIPTION
## Done
- Remove empty categories from IoT page and desktop page

## QA
- Check out this feature branch (`238-add-pagination-to-homepage`)
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023](http://0.0.0.0:8023)
- Check that videos and white papers do not appear in the IoT navigation dropdown
- Check that webinars do not appear in the Desktop navigation dropdown
- Go to [http://0.0.0.0:8023/internet-of-things](http://0.0.0.0:8023/internet-of-things)
- Check that videos and white papers do not appear in the filters box
- Go to [http://0.0.0.0:8023/desktop](http://0.0.0.0:8023/desktop)
- Check that webinars do not appear in the filters box


## Issue / Card
[Fixes #243](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/243)
