### PR TITLE
Add archives link to footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -89,6 +89,7 @@
                 <li class="p-inline-list__item"><a href="http://www.ubuntu.com/privacy-policy" class="p-link--external">Privacy policy</a></li>
                 <li class="p-inline-list__item"><a class="screen-only p-link--external" href="https://github.com/canonical-websites/insights.ubuntu.com/issues">Report a bug on this site</a></li>
                 <li class="p-inline-list__item"><a href="/feed/">RSS feed</a></li>
+                <li class="p-inline-list__item"><a href="/archives">Archives</a></li>
               </ul>
               <span class="u-off-screen">
                 <a href="#">Go to the top of the page</a>


### PR DESCRIPTION
## Done

- Add archives link to fotoer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- See that archives link is present in the footer


## Issue / Card

[Fixes #159](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/159)

## Screenshots

![ubuntu insights](https://user-images.githubusercontent.com/501889/37517402-3592d348-2909-11e8-9f2a-eff910df6090.jpg)

