### PR TITLE
Temporary redirect for nvidia-gtc-2018

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -21,3 +21,6 @@
 /page/(?P<page>[0-9]+)/(?P<group>[^/]+)/?: /archives?group={group}&page={page}
 /group/(?P<group>[^/]+)/?: /archives?group={group}
 /topic/(?P<group>(canonical-announcements|cloud|desktop|internet-of-things))/?: /archives?group={group}
+
+# temporary redirect for a bad link in an email
+/event/mobile-world-congress-2018/?:  /2018/03/14/nvidia-gtc-2018


### PR DESCRIPTION
## Done

- Temporary redirect for nvidia-gtc-2018

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- test that the redirect from [/event/mobile-world-congress-2018](http://0.0.0.0:8023/event/mobile-world-congress-2018) to [/2018/03/14/nvidia-gtc-2018](http://0.0.0.0:8023/2018/03/14/nvidia-gtc-2018) works

