### PR TITLE
Add optional featured images to posts

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,6 +8,7 @@ import feeds
 
 API_URL = 'https://admin.insights.ubuntu.com/wp-json/wp/v2'
 
+
 def _embed_resource_data(resource):
     if '_embedded' not in resource:
         return resource
@@ -17,10 +18,12 @@ def _embed_resource_data(resource):
     resource['featuredmedia'] = embedded['wp:featuredmedia'][0]
     return resource
 
+
 def _normalise_resources(posts):
     for post in posts:
         post = _embed_resource_data(post)
     return posts
+
 
 def get(endpoint, parameters={}):
     """

--- a/api.py
+++ b/api.py
@@ -8,6 +8,19 @@ import feeds
 
 API_URL = 'https://admin.insights.ubuntu.com/wp-json/wp/v2'
 
+def _embed_resource_data(resource):
+    if '_embedded' not in resource:
+        return resource
+    embedded = resource['_embedded']
+    if 'wp:featuredmedia' not in embedded:
+        return resource
+    resource['featuredmedia'] = embedded['wp:featuredmedia'][0]
+    return resource
+
+def _normalise_resources(posts):
+    for post in posts:
+        post = _embed_resource_data(post)
+    return posts
 
 def get(endpoint, parameters={}):
     """
@@ -103,6 +116,8 @@ def get_posts(
             response.headers.get('X-WP-Total'),
             None
         )
+
+    posts = _normalise_resources(posts)
 
     return posts, total_posts, total_pages
 

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -41,11 +41,18 @@
         <h5 class="p-muted-heading">{{ post.group.name }}</h5>
       </header>
       <div class="p-card__content">
+        {% if post.featuredmedia %}
+        <a href="{{post.link}}">
+          <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
+        </a>
+        {% endif %}
         <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
         {% if post.author %}
           <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
         {% endif %}
+        {% if not post.featuredmedia %}
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
+        {% endif %}
       </div>
       <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
     </div>


### PR DESCRIPTION
## Done

- Add option to show thumbnails on posts

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that the ninth post on the homepage has a thumbnail and no intro text same as <https://www.ubuntu.com/resources>


## Issue / Card

[Fixes #255](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/255)

## Screenshots

![ubuntu insights](https://user-images.githubusercontent.com/501889/37530200-f27931a6-2930-11e8-86fb-815572f591d4.jpg)
