### PR TITLE
Added route for /webinar/slug route

### DIFF
--- a/app.py
+++ b/app.py
@@ -371,7 +371,10 @@ def feed(type=None, slug=None): # noqa
     '/<regex("[0-9]{2}"):day>'
     '/<slug>'
 )
-def post(year, month, day, slug):
+@app.route(
+    '/webinar/<slug>'
+)
+def post(slug, year=None, month=None, day=None):
     posts, total_posts, total_pages = helpers.get_formatted_posts(slugs=[slug])
 
     if not posts:


### PR DESCRIPTION
## Done

- Added route for /webinar/slug route

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a traditional webinar link](http://0.0.0.0:8023/webinar/get-ready-for-multi-cloud/)
- See that it looks identical to https://insights.ubuntu.com/2017/12/02/get-ready-for-multi-cloud

## Issue / Card

Fixes #266

