### PR TITLE
Remove is-bordered class and replace with is-shallow for webinar strip

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@
 
   {% include "pagination.html" %}
 
-<div class="p-strip is-bordered">
+<div class="p-strip is-shallow">
   <div class="row">
     <h2>Webinars</h2>
   </div>


### PR DESCRIPTION
## Done

Remove `is-bordered` class and replace with `is-shallow` on webinar strip

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that webinar strip only has one border at bottom and spacing is less than in production


## Issue / Card

[Fixes #200](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/200)
