### PR TITLE
Made newsletter signup sticky on article pages

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -150,12 +150,6 @@ pre {
   }
 }
 
-.right-rail {
-  display: flex !important;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
 // XXX Ant: 06.02.2018
 // Can be removed when upgrading to vanilla v1.6.6 >
 .p-navigation .p-navigation__link {

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -1,4 +1,4 @@
-<div class="p-card">
+<div class="p-card" style="position: sticky; top: 0;">
   <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
     <h3 class="p-card--title p-heading--four">Sign up for email updates</h3>
     <div class="p-card--content">

--- a/templates/post.html
+++ b/templates/post.html
@@ -85,7 +85,7 @@
         {{ post.content.rendered | safe }}
       </div>
     </div>
-    <div class="col-4 right-rail">
+    <div class="col-4">
       {# right rail #}
       {% include 'product-cards.html' %}
       {% include 'newsletter-form.html' %}


### PR DESCRIPTION
## Done

- Made newsletter signup sticky on article pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any post](http://0.0.0.0:8023/2018/03/14/maas-2-4-0-alpha-2-released)
- See that the newsletter is at the top of the column and scroll in place on the Where are you down

## Issue / Card

Fixes #258

