### PR TITLE
Vertically centre social widget on small screens

### DIFF
--- a/static/sass/_pattern_social-share.scss
+++ b/static/sass/_pattern_social-share.scss
@@ -14,6 +14,11 @@
     width: 33px;
   }
 
+  .p-social-widget {
+    display: flex;
+    align-items: center;
+  }
+
   .p-social-icon--facebook {
     @extend %p-social-share;
     background-color: #265292;

--- a/templates/post.html
+++ b/templates/post.html
@@ -37,7 +37,7 @@
       </div>
     </div>
     <div class="col-4">
-      <ul class="p-inline-list u-vertically-center">
+      <ul class="p-inline-list u-vertically-center p-social-widget">
         <li class="p-inline-list__item">
           Share on:
         </li>


### PR DESCRIPTION
## Done

Vertically centre social icons on small screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to [any post](http://0.0.0.0:8023/2018/03/19/firefox-quantum-snap-now-available-on-linux-based-devices)
- Check that social share icons are vertically centred when you resize your browser to a narrow width


## Issue / Card

Fixes #195

