### PR TITLE
Fix search reset button

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,19 @@
+(function() {
+  function handleSearch(searchBox) {
+    let searchBoxes = Array.prototype.slice.call(
+      document.querySelectorAll(searchBox)
+    );
+
+    searchBoxes.forEach(searchBox => {
+      let searchBoxInput = searchBox.querySelector('.p-search-box__input');
+      let searchBoxResetBtn = searchBox.querySelector('.p-search-box__reset');
+
+      searchBoxResetBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        searchBoxInput.value = '';
+      }, false);
+    });
+  }
+
+  handleSearch('.p-search-box');
+})();

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -101,6 +101,7 @@
     </div>
     <script src="/static/js/modules/cookie-policy.js"></script>
     <script src="/static/js/aria-controls.js"></script>
+    <script src="/static/js/search.js"></script>
     <script src="/static/js/modules/global.js"></script>
     <script>
       var options = {


### PR DESCRIPTION
## Done

- Add event listener to search reset to clear input as default behaviour doesn't clear input if page is loaded with a value in the input

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/search?q=hello](http://0.0.0.0:8023/search?q=hello)
- Click the 'x' button on the search and check that it clears the value from the input

## Issue / Card
Fixes #212 
