### PR TITLE
Focus search input after clearing

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -11,6 +11,7 @@
       searchBoxResetBtn.addEventListener('click', function(e) {
         e.preventDefault();
         searchBoxInput.value = '';
+        searchBoxInput.focus();
       }, false);
     });
   }


### PR DESCRIPTION
## Done

Focuses search input after hitting the reset button

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8023/search?q=hi>
- Clear the search input by clicking on the 'x'
- Try typing, the input should reflect what you type

## Issue / Card

Fixes #281 