### PR TITLE
Updated author blocks with new API data

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -5,12 +5,33 @@
     <div class="col-8">
       <div class="p-media-object">
         {# author.id 217 is Canonical, which needs the icon and description added manually #}
-        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
+        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% elif author.user_photo %}{{ author.user_photo }}{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">
             {{ author.name }}
           </h1>
+          {% if author.user_job_title %}<p class="p-media-object__content"><em>{{ author.user_job_title }}</em></p>{% endif %}
+
           <p class="p-media-object__content">{% if author.id == 217 %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% else %}{{ author.description | safe }}{% endif %}</p>
+
+          <ul class="p-inline-list">
+            {% if author.user_google %}
+            <li class="p-inline-list__item">
+              <a href="https://plus.google.com/{{ author.user_google | replace("https://plus.google.com/", "") | replace("plus.google.com/", "") | replace("/", "") }}"><i class="p-icon--google"></i></a>
+            </li>
+            {% endif %}
+            {% if author.user_twitter %}
+            <li class="p-inline-list__item">
+              <a href="https://twitter.com/{{ author.user_twitter | replace("@", "") }}"><i class="p-icon--twitter"></i></a>
+            </li>
+            {% endif %}
+            {% if author.user_facebook %}
+            <li class="p-inline-list__item">
+              <a href="https://www.facebook.com/{{ author.user_facebook }}"><i class="p-icon--facebook"></i></a>
+            </li>
+            {% endif %}
+          </ul>
+
         </div>
       </div>
     </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -24,7 +24,7 @@
       <div class="p-media-object">
         {% if post.author %}
           {# post.author.id 217 is Canonical, which needs the icon added manually #}
-          <img src="{% if post.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ post.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
+          <img src="{% if post.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% elif post.author.user_photo %}{{ post.author.user_photo }}{% else %}{{ post.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="{{ post.author.name }}">
         {% endif %}
         <div class="p-media-object__details">
           {% if post.author %}


### PR DESCRIPTION
## Done

- Updated author blocks with new API data

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [author page](http://0.0.0.0:8023/author/kirkland)
  - [blog page](http://0.0.0.0:8023/2018/01/04/ubuntu-updates-for-the-meltdown-spectre-vulnerabilities)
- Compare to:
  - [insights author](https://insights.ubuntu.com/author/kirkland) and [admin author](https://admin.insights.ubuntu.com/author/kirkland)
  - see that the new data has been pulled in (image, title and social media) and the social urls work

## Issue / Card

Fixes #284

## Screenshots

post
![image](https://user-images.githubusercontent.com/441217/37931686-64e712ac-313e-11e8-8d23-49966537ef87.png)

author page
![image](https://user-images.githubusercontent.com/441217/37931705-7499a7a0-313e-11e8-8b63-542464af8b9a.png)


