### PR TITLE
Add padding to the top of the sticky newsletter

### DIFF
--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -1,4 +1,4 @@
-<div class="p-card" style="position: sticky; top: 0;">
+<div class="p-card" style="position: sticky; top: 2rem;">
   <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
     <h3 class="p-card--title p-heading--four">Sign up for email updates</h3>
     <div class="p-card--content">


### PR DESCRIPTION
## Done
Added the same top offset to the newsletter sign up card as between the above box.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Go to a post page
- Scroll down and see that the newsletter sign up box sticks with consistent padding top.

## Issue / Card
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/285
