### PR TITLE
insights.ubuntu.com upgrade vanilla-framework to v1.7.0-alpha-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.6.5",
+    "vanilla-framework": "1.7.0-alpha-1",
     "watch-cli": "^0.2.2"
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -121,14 +121,6 @@ pre {
   }
 }
 
-// XXX Caleb - 30.01.18 Nav search box styling fixes
-.p-navigation .p-navigation__nav > .p-search-box {
-  @media (min-width: $breakpoint-navigation-threshold + 1) {
-    margin-top: 2px;
-    max-width: 15rem;
-  }
-}
-
 // XXX Caleb - 30.01.18 Custom hide utilities for navigation breakpoints
 .u-hide--nav-large {
   @media (min-width: $breakpoint-navigation-threshold + 1) {
@@ -150,22 +142,9 @@ pre {
   }
 }
 
-// XXX Ant: 06.02.2018
-// Can be removed when upgrading to vanilla v1.6.6 >
-.p-navigation .p-navigation__link {
-  > a {
-    border-bottom: 3px solid transparent;
-  }
-
-  &.is-selected > a {
-    border-bottom-color: $color-mid-dark;
-  }
-}
-
 .p-post__content {
   max-width: 35em;
 }
-
 
 .link-cta-ubuntu {
   @extend .p-button--positive;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -37,7 +37,6 @@
     <!-- End Google Tag Manager -->
 
     <header id="navigation" class="p-navigation">
-      <div class="row">
         <div class="p-navigation__banner">
           <div class="p-navigation__logo">
             <a class="p-navigation__link" href="/">
@@ -72,8 +71,6 @@
         </div>
 
         {% include "main-nav.html" %}
-
-      </div>
     </header>
 
     {% block body %}{% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,9 +2490,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
+vanilla-framework@1.7.0-alpha-1:
+  version "1.7.0-alpha-1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-alpha-1.tgz#cbf6ce65c97a3cece65a0bb6274904cf81918b94"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
Updated vanilla-framework to 1.7.0-alpha-1 and changed the logo link to be relative.

## QA
Check out the demo and see if there are issues.