### PR TITLE
Add open graph image

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,6 +5,12 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if post and post.featuredmedia %}
+      <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
+    {% else %}
+      <meta property="og:image" content="https://assets.ubuntu.com/v1/33a3ce22-38018856-02eda0bc-326e-11e8-872e-0b6d5ddb990b.jpg" />
+    {% endif %}
+
     {% if self.title() %}
       <title>{% block title %}{% endblock %} | Ubuntu Insights</title>
     {% else %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,10 +5,26 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% if post and post.featuredmedia %}
-      <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
-    {% else %}
-      <meta property="og:image" content="https://assets.ubuntu.com/v1/33a3ce22-38018856-02eda0bc-326e-11e8-872e-0b6d5ddb990b.jpg" />
+    {% if post %}
+      {% if post.featuredmedia %}
+        <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
+      {% else %}
+        <meta property="og:image" content="https://assets.ubuntu.com/v1/33a3ce22-38018856-02eda0bc-326e-11e8-872e-0b6d5ddb990b.jpg" />
+      {% endif %}
+
+      {% if self.title() %}
+        <meta property="og:title" content="{% block title %}{% endblock %} | Ubuntu Insights" />
+      {% else %}
+        <meta property="og:title" content="Ubuntu Insights" />
+      {% endif %}
+
+      {% if post.link %}
+        <meta property="og:url" content="{% post.link %}" />
+      {% endif %}
+
+      {% if post.summary %}
+        <meta property="og:description" content="{% post.summary %}" />
+      {% endif %}
     {% endif %}
 
     {% if self.title() %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,18 +12,18 @@
         <meta property="og:image" content="https://assets.ubuntu.com/v1/33a3ce22-38018856-02eda0bc-326e-11e8-872e-0b6d5ddb990b.jpg" />
       {% endif %}
 
-      {% if self.title() %}
-        <meta property="og:title" content="{% block title %}{% endblock %} | Ubuntu Insights" />
-      {% else %}
-        <meta property="og:title" content="Ubuntu Insights" />
-      {% endif %}
-
       {% if post.link %}
-        <meta property="og:url" content="{% post.link %}" />
+        <meta property="og:url" content="{{post.link}}" />
       {% endif %}
 
       {% if post.summary %}
-        <meta property="og:description" content="{% post.summary %}" />
+        <meta property="og:description" content="{{post.summary}}" />
+      {% endif %}
+
+      {% if post.title %}
+        <meta property="og:title" content="{{post.title}}" />
+      {% else %}
+        <meta property="og:title" content="Ubuntu Insights" />
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
## Done

Set featured image to be displayed by Facebooks open graph meta tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Choose a post with a featured image (a thumbnail on the card) and if possible share on a facebook account. It should feature the same image
- Choose a post with no featured image and if possible share on a facebook account. It should feature the default insights logo on a suru background.


## Issue / Card

Fixes #283 
