### PR TITLE
Cleanup og title and description

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -17,11 +17,11 @@
       {% endif %}
 
       {% if post.summary %}
-        <meta property="og:description" content="{{post.summary}}" />
+        <meta property="og:description" content="{{post.summary | striptags}}" />
       {% endif %}
 
       {% if post.title %}
-        <meta property="og:title" content="{{post.title}}" />
+        <meta property="og:title" content="{{post.title.rendered | safe}}" />
       {% else %}
         <meta property="og:title" content="Ubuntu Insights" />
       {% endif %}


### PR DESCRIPTION
## Done

This fixes the OpenGraph post title and description.

Currently, they render like this:
![screenshot from 2018-04-05 10-45-12](https://user-images.githubusercontent.com/18480003/38355885-744b35f2-38be-11e8-85c2-945036cac4cf.png)

With this fix:
![screenshot from 2018-04-05 10-50-00](https://user-images.githubusercontent.com/18480003/38356114-257852a6-38bf-11e8-958f-07c3f08684a9.png)


## QA

- Test posts from the demo site with an OG debugger such as https://developers.facebook.com/tools/debug/sharing/