### PR TITLE
Shore up get_first_group against missing groups

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -57,7 +57,7 @@ def get_first_group(group_ids, force_group=None):
     else:
         group_id = group_ids[0] if group_ids else None
 
-    return api.get_group(group_id)
+    return api.get_group(group_id) if group_id else None
 
 
 def get_first_category(category_ids):


### PR DESCRIPTION
It was the case that a post without a group in a post list page caused a server error. This should fix that.

Fixes #293

QA
--

`./run` and go to http://0.0.0.0:8023/tag/support. Tada! No error!