### PR TITLE
Remove angle bracket

### DIFF
--- a/templates/accordion-signup-form.html
+++ b/templates/accordion-signup-form.html
@@ -12,7 +12,7 @@
         </div>
       </div>
       <section class="p-accordion__panel" id="accordion-form" role="tabpanel" aria-hidden="true" aria-labelledby="accordion-form-tab">
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');"></form>>
+        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');"></form>
           <div class="row">
             <div class="col-12">
               <p>Choose the topics you&rsquo;re interested in</p>


### PR DESCRIPTION
# Done
Remove errant angle bracket in signup accordion

# QA
Go to <http://0.0.0.0:8023/home> and open accordion and make sure there is no angle bracket on the left of the panel 
