### PR TITLE
Update cookie-policy dependancy to prevent grid classes from overriding patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Canonical webteam",
   "devDependencies": {
     "autoprefixer": "^7.1.3",
-    "cookie-policy": "^0.0.1",
+    "cookie-policy": "^1.0.5",
     "global-nav": "^0.2.2",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",


### PR DESCRIPTION
Old version is raising specificity of grid classes, which overrides things it shoudln't - e.g. 
.row .col-4 {...}

As a result, trying to set a modified .p-card to display:flex (so I can align children like a card footer to bottom of card) would require an !Important. 


## Done

Update package json to include a newer version of the cookie-policy dependancy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
