### PR TITLE
Rewrite cards to be built out of existing components, rather than rely on bespoke styles

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -3,10 +3,6 @@
   .p-card__category {
     background: url('#{$assets-path}ed42aefa-icon-resource-hub-icon-document.png') left center no-repeat;
     color: $color-mid-dark;
-    font-size: $sp-medium;
-    line-height: 1.5;
-    padding: 0 0 0 $sp-large;
-    text-transform: uppercase;
 
     > a:link,
     > a:visited {
@@ -21,92 +17,51 @@
     }
   }
 
-  %post-card-header {
-    border-radius: 2px;
-    padding: $sp-small $sp-medium;
+  %flex-column {
+    display: flex;
+    flex-direction: column;
   }
 
   .p-card--post {
-    @extend .p-card--highlighted;
-    display: flex !important;
-    flex-direction: column;
-    padding: 0;
-
-    > .p-card__content {
-      border-top: 1px dotted $color-mid-light;
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      margin: 0 $sp-x-small;
-      padding: $sp-x-small;
-
-      > a, h3, p {
-        display: block;
-        margin: $sp-x-small 0;
-      }
-    }
-
-    .p-card__footer {
-      border-top: 1px dotted $color-mid-light;
-      font-size: .875rem;
-      margin: auto $sp-x-small 0;
-      max-width: inherit;
-      padding: $sp-medium $sp-x-small;
-    }
-  }
-
-  .p-card--muted {
-    @extend .p-card;
-    background-color: $color-light;
-    margin-bottom: 0;
-    padding: 0;
-    box-shadow: 0 1px 2px 0 transparentize($color-dark, .8);
-
-    > .p-card__header  {
-      margin-bottom: 0;
-      border-top: 3px solid $color-light;
-      border-bottom: 0;
-    }
-
-    > .p-card__content {
-      margin: 0 $sp-x-small $sp-x-small;
-      padding: $sp-medium $sp-x-small $sp-x-small;
-      border-top: 1px dotted $color-mid-light;
-    }
-  }
-
-  .p-card__header {
-    @extend %post-card-header;
-
     &--cloud-and-server {
-      @extend %post-card-header;
-      border-top: 3px solid #a87ca0;
+      @extend %p-card--highlighted;
+      @extend %flex-column;
+      @include vf-m-category-bar(#a87ca0);
     }
 
     &--desktop {
-      @extend %post-card-header;
-      border-top: 3px solid #48929b;
+      @extend %flex-column;
+      @extend %p-card--highlighted;
+      @include vf-m-category-bar(#48929b);
     }
 
     &--internet-of-things {
-      @extend %post-card-header;
-      border-top: 3px solid #8db255;
+      @extend %flex-column;
+      @extend %p-card--highlighted;
+      @include vf-m-category-bar(#8db255);
     }
 
     &--canonical-announcements {
-      @extend %post-card-header;
-      border-top: 3px solid #ff8936;
+      @extend %flex-column;
+      @extend %p-card--highlighted;
+      @include vf-m-category-bar(#ff8936);
     }
 
     &--phone-and-tablet {
-      @extend %post-card-header;
-      border-top: 3px solid $color-mid-light;
+      @extend %flex-column;
+      @extend %p-card--highlighted;
+      @include vf-m-category-bar($color-mid-light);
     }
 
     &--webinar {
-      @extend %post-card-header;
-      border-top: 3px solid #48929b;
+      @extend %flex-column;
+      @extend %p-card--highlighted;
+      @include vf-m-category-bar(#48929b);
     }
+  }
+
+  .p-card__footer {
+    margin-top: auto;
   }
 
   .p-card__date {

--- a/templates/alternate_index.html
+++ b/templates/alternate_index.html
@@ -39,8 +39,8 @@
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">
   {% endif %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--webinar">
+    <div class="col-4 p-card--post--webinar">
+      <header class="p-card__header">
         <h5 class="p-muted-heading">{{ webinar.tags[0].term | safe }}</h5>
       </header>
       <div class="p-card__content">

--- a/templates/alternate_posts.html
+++ b/templates/alternate_posts.html
@@ -32,7 +32,8 @@
       </div>
     </div>
   {% endif %}
-
+</div>
+<div class="p-strip is-shallow" id="posts-list">
 {%- for post in posts %}
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">

--- a/templates/featured-posts.html
+++ b/templates/featured-posts.html
@@ -8,13 +8,11 @@
   </div>
   {%- for post in featured_posts %}
   {% if loop.index0 % 3 == 0 %}
-  <div class="row u-equal-height u-clearfix">
+  <div class="row u-equal-height">
   {% endif %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--{{ post.group.slug }}">
+    <div class="col-4 p-card--post--{{ post.group.slug }}">
         <h5 class="p-muted-heading">{{ post.group.name }}</h5>
-      </header>
-      <div class="p-card__content">
+        <hr>
         {% if post.featuredmedia %}
         <a href="{{post.link}}">
           <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
@@ -25,10 +23,14 @@
           <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
         {% endif %}
         {% if not post.featuredmedia %}
-        <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
+        <p class="">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
-      </div>
-      <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+        {% if post.category.name %}
+        <div class="p-card__footer">
+          <hr>
+          <small>{{ post.category.name }}</small>
+        </div>
+        {% endif %}
     </div>
   {% if loop.index0 % 3 == 2 or loop.last %}
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,26 +37,26 @@
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">
   {% endif %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--webinar">
-        <h5 class="p-muted-heading">{{ webinar.tags[0].term | safe }}</h5>
-      </header>
-      <div class="p-card__content">
-        <a href="{{ webinar.links[0].href | safe }}">
-          <img src="{{ webinar.links[2].href }}" alt="" />
-        </a>
-        <h3 class="p-heading--four"><a href="{{ webinar.links[0].href | safe }}">{{ webinar.title_detail.value | safe }}</a></h3>
-        <p>{{ webinar.summary | truncate (150, False, '&hellip;') | safe }}</p>
-        <ul class="p-card__date">
-          <li class="p-media-object__meta-list-item--date">
-            <span class="u-off-screen">Date: </span>
-            <a href="https://www.brighttalk.com/service/channel/channel/6793/communication/{{ webinar.bt_communication.id }}/calendar/ics">
-              {{ webinar.updated_datetime.strftime('%d %B %Y') }}
-            </a>
-          </li>
-        </ul>
+    <div class="col-4 p-card--post--webinar">
+      <h5 class="p-muted-heading">{{ webinar.tags[0].term | safe }}</h5>
+      <hr>
+      <a href="{{ webinar.links[0].href | safe }}">
+        <img src="{{ webinar.links[2].href }}" alt="" />
+      </a>
+      <h3 class="p-heading--four"><a href="{{ webinar.links[0].href | safe }}">{{ webinar.title_detail.value | safe }}</a></h3>
+      <p>{{ webinar.summary | truncate (150, False, '&hellip;') | safe }}</p>
+      <ul class="p-card__date">
+        <li class="p-media-object__meta-list-item--date">
+          <span class="u-off-screen">Date: </span>
+          <a href="https://www.brighttalk.com/service/channel/channel/6793/communication/{{ webinar.bt_communication.id }}/calendar/ics">
+            {{ webinar.updated_datetime.strftime('%d %B %Y') }}
+          </a>
+        </li>
+      </ul>
+      <div class="p-card__footer">
+        <hr>
+        <small>Webinar</small>
       </div>
-      <p class="p-card__footer">Webinar</p>
     </div>
   {% if loop.index0 % 3 == 2 or loop.last %}
   </div>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,6 +1,6 @@
 {% block posts %}
 
-<div class="p-strip is-shallow u-no-padding--top u-no-padding--bottom" id="posts-list">
+<div id="posts-list">
   {% if not tag %}
     <div class="row">
       <div class="col-12 u-align--right">
@@ -32,67 +32,63 @@
       </div>
     </div>
   {% endif %}
-
+</div>
+<div class="p-strip is-shallow" id="posts-list">
 {%- for post in posts %}
   {% if loop.index0 % 3 == 0 %}
-  <div class="row u-equal-height u-clearfix">
+  <div class="row u-equal-height">
   {% endif %}
   {% if loop.index0 == 2 %}
-  <div class="col-4 p-card--muted">
-    <header class="p-card__header">
+    <div class="col-4 p-card--muted">
       <h5 class="p-muted-heading">Newsletter signup</h5>
-    </header>
-    <div class="p-card__content">
+      <hr>
       <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
-        <div class="p-card--content">
-          <ul class="p-list">
-            <li class="p-list__item u-no-margin--top">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
-              <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
-            </li>
-            <li class="p-list__item u-no-margin--top">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
-              <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
-            </li>
-            <li class="p-list__item u-no-margin--top">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
-              <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
-            </li>
-            <li class="p-list__item u-no-margin--top">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
-              <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
-            </li>
-          </ul>
-          <div class="mktFormReq mktField u-margin-medium--top">
-              <label class="u-no-margin--top" for="Email" class="mktolabel u-no-margin--top">Work email: <span>*</span></label>
-              <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
-          </div>
-          <div class="mktField mktLblRight u-margin-medium--top">
-            <span class="mktInput mktLblRight">
-              <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-              <label class="p-form__label u-no-margin--top" for="canonicalUpdatesOptIn">I would like to receive occasional updates from Canonical by email.</label><span class="mktFormMsg"></span>
-            </span>
-          </div>
-          <div class="u-margin-medium--top">
-            <span class="mktoButtonWrap p-card--content">
-              <button type="submit" class="mktoButton">Subscribe now</button>
-            </span>
-            <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-            <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-            <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
-            <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
-            <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-            <input name="kw" value="" type="hidden">
-            <input name="cr" value="" type="hidden">
-            <input name="searchstr" value="" type="hidden">
-            <input name="_mkt_disp" value="return" type="hidden">
-            <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-          </div>
-        </form>
+        <ul class="p-list">
+          <li class="p-list__item">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+            <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
+          </li>
+          <li class="p-list__item">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+            <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
+          </li>
+          <li class="p-list__item">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+            <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
+          </li>
+          <li class="p-list__item">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+            <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
+          </li>
+        </ul>
+        <div class="mktFormReq mktField">
+            <label class="u-no-margin--top" for="Email" class="mktolabel">Work email: <span>*</span></label>
+            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
         </div>
-      </div>
+        <div class="mktField mktLblRight">
+          <span class="mktInput mktLblRight">
+            <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+            <label class="p-form__label" for="canonicalUpdatesOptIn">I would like to receive occasional updates from Canonical by email.</label><span class="mktFormMsg"></span>
+          </span>
+        </div>
+        <div class="">
+          <span class="mktoButtonWrap">
+            <button type="submit" class="mktoButton">Subscribe now</button>
+          </span>
+          <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+          <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+          <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
+          <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+          <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
+          <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+          <input name="kw" value="" type="hidden">
+          <input name="cr" value="" type="hidden">
+          <input name="searchstr" value="" type="hidden">
+          <input name="_mkt_disp" value="return" type="hidden">
+          <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+        </div>
+      </form>
       <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
       <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
       <script>
@@ -106,26 +102,26 @@
         });
       </script>
     </div>
-  {% else %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--{{ post.group.slug }}">
-        <h5 class="p-muted-heading">{{ post.group.name }}</h5>
-      </header>
-      <div class="p-card__content">
-        {% if post.featuredmedia %}
-        <a href="{{post.link}}">
-          <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
-        </a>
-        {% endif %}
-        <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
-        {% if post.author %}
-          <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
-        {% endif %}
-        {% if not post.featuredmedia %}
-        <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
-        {% endif %}
+    {% else %}
+    <div class="col-4 p-card--post--{{ post.group.slug }}">
+      <h5 class="p-muted-heading">{{ post.group.name }}</h5>
+      <hr>
+      {% if post.featuredmedia %}
+      <a href="{{post.link}}">
+        <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
+      </a>
+      {% endif %}
+      <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
+      <div class="p-card__footer">
+      {% if post.author %}
+        <p class="u-align--bottom"><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
+      {% endif %}
+      {% if not post.featuredmedia %}
+      <p class="">{{ post.summary | striptags | urlize(30, true) }}</p>
+      {% endif %}
+        <hr>
+        <small>{{ post.category.name | capitalize }}</small>
       </div>
-      <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
     </div>
   {% endif %}
   {% if loop.index0 % 3 == 2 or loop.last %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,9 +391,9 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-cookie-policy@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-0.0.1.tgz#98d876c0c52282144cdddccff127446a2a65897d"
+cookie-policy@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-1.0.5.tgz#be71abae448c07fe97e5a0b1234d628e835072c3"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Done

This was done as part of vanilla 1.7.0.beta work following discussions in WG meeting on 16.04.18.  
The aim of this is:

• Reduce the amount of snowflake code on various sites
• identify commonly needed modifications to the building blocks of bigger composite components - (like smaller margins under headings inside narrow containers)
• provide modified versions of these atomic building blocks, which can then be included into any composite component requiring those, rather than repeatedly redefining the same modifications with pattern-specific classes
• ensure they all extend the same placeholders, so that css output is minimal
 
N.B.: Should not be merged before the site is transitioned to 1.7.0 official.
 
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
