### PR TITLE
Remove brighttalk section and feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,10 +171,7 @@ def homepage():
         current_page=page,
         total_posts=total_posts,
         total_pages=total_pages,
-        featured_posts=featured_posts,
-        webinars=feeds.get_rss_feed_content(
-            'https://www.brighttalk.com/channel/6793/feed'
-        )
+        featured_posts=featured_posts
     )
 
 
@@ -212,10 +209,7 @@ def alternate_homepage():
         current_page=page,
         total_posts=total_posts,
         total_pages=total_pages,
-        featured_posts=featured_posts,
-        webinars=feeds.get_rss_feed_content(
-            'https://www.brighttalk.com/channel/6793/feed'
-        )
+        featured_posts=featured_posts
     )
 
 

--- a/templates/alternate_index.html
+++ b/templates/alternate_index.html
@@ -31,38 +31,4 @@
 
 {% include "pagination.html" %}
 
-<div class="p-strip is-shallow">
-  <div class="row">
-    <h2>Webinars</h2>
-  </div>
-  {%- for webinar in webinars %}
-  {% if loop.index0 % 3 == 0 %}
-  <div class="row u-equal-height u-clearfix">
-  {% endif %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--webinar">
-        <h5 class="p-muted-heading">{{ webinar.tags[0].term | safe }}</h5>
-      </header>
-      <div class="p-card__content">
-        <a href="{{ webinar.links[0].href | safe }}">
-          <img src="{{ webinar.links[2].href }}" alt="" />
-        </a>
-        <h3 class="p-heading--four"><a href="{{ webinar.links[0].href | safe }}">{{ webinar.title_detail.value | safe }}</a></h3>
-        <p>{{ webinar.summary | truncate (150, False, '&hellip;') | safe }}</p>
-        <ul class="p-card__date">
-          <li class="p-media-object__meta-list-item--date">
-            <span class="u-off-screen">Date: </span>
-            <a href="https://www.brighttalk.com/service/channel/channel/6793/communication/{{ webinar.bt_communication.id }}/calendar/ics">
-              {{ webinar.updated_datetime.strftime('%d %B %Y') }}
-            </a>
-          </li>
-        </ul>
-      </div>
-      <p class="p-card__footer">Webinar</p>
-    </div>
-  {% if loop.index0 % 3 == 2 or loop.last %}
-  </div>
-  {% endif %}
-  {%- endfor %}
-</div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,38 +29,4 @@
 
 {% include "pagination.html" %}
 
-<div class="p-strip is-shallow">
-  <div class="row">
-    <h2>Webinars</h2>
-  </div>
-  {%- for webinar in webinars %}
-  {% if loop.index0 % 3 == 0 %}
-  <div class="row u-equal-height u-clearfix">
-  {% endif %}
-    <div class="col-4 p-card--post">
-      <header class="p-card__header--webinar">
-        <h5 class="p-muted-heading">{{ webinar.tags[0].term | safe }}</h5>
-      </header>
-      <div class="p-card__content">
-        <a href="{{ webinar.links[0].href | safe }}">
-          <img src="{{ webinar.links[2].href }}" alt="" />
-        </a>
-        <h3 class="p-heading--four"><a href="{{ webinar.links[0].href | safe }}">{{ webinar.title_detail.value | safe }}</a></h3>
-        <p>{{ webinar.summary | truncate (150, False, '&hellip;') | safe }}</p>
-        <ul class="p-card__date">
-          <li class="p-media-object__meta-list-item--date">
-            <span class="u-off-screen">Date: </span>
-            <a href="https://www.brighttalk.com/service/channel/channel/6793/communication/{{ webinar.bt_communication.id }}/calendar/ics">
-              {{ webinar.updated_datetime.strftime('%d %B %Y') }}
-            </a>
-          </li>
-        </ul>
-      </div>
-      <p class="p-card__footer">Webinar</p>
-    </div>
-  {% if loop.index0 % 3 == 2 or loop.last %}
-  </div>
-  {% endif %}
-  {%- endfor %}
-</div>
 {% endblock %}


### PR DESCRIPTION
## Done

- Remove webinar (Brighttalk) section from homepage
- Remove webinar (Brighttalk) feed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that the webinar section is no longer on the homepage


## Issue / Card

Fixes #289 