### PR TITLE
Fix navigation bugs related to vanilla 1.7.0

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -1,0 +1,54 @@
+@mixin insights-p-navigation {
+
+  .p-navigation {
+    .hover-menu {
+      display: none;
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold + 1) {
+      &__links {
+        border-right: 1px solid $color-mid-light;
+      }
+
+      &__link:hover .hover-menu {
+        display: block;
+        z-index: 10;
+      }
+
+      .p-search-box {
+        max-width: 14rem;
+      }
+
+      .hover-menu {
+        background: $color-x-light;
+        border: 1px solid $color-mid-light;
+        border-radius: 10px;
+        box-shadow: 0 2px 2px -1px $color-mid-light;
+        margin: 0;
+        padding: $sp-x-small 0 $sp-medium;
+        position: absolute;
+        top: 51px;
+        width: 200px;
+        z-index: 1;
+
+        &::after {
+          background: url('https://assets.ubuntu.com/v1/b70e6370-nav-arrow-white.svg') $sp-large bottom no-repeat;
+          content: '';
+          height: $sp-small;
+          position: absolute;
+          top: -7px;
+          width: 100%;
+        }
+
+        &__item {
+          font-size: .875rem;
+          padding: $sp-small $sp-small 0 $sp-small;
+
+          > a:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+}

--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -1,0 +1,1 @@
+$breakpoint-navigation-threshold: 990px;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,16 +1,22 @@
 @charset 'UTF-8';
 
-$breakpoint-navigation-threshold: 990px;
+// Import custom scss settings
+@import 'settings';
 
+// Import Vanilla
 @import 'vanilla-framework/scss/build';
-@import 'pattern_social-share';
-@import 'pattern_rtp';
+
+// Import and include custom scss
 @import 'pattern_card';
+@import 'pattern_navigation';
+@import 'pattern_rtp';
+@import 'pattern_social-share';
 @import 'pattern_strips';
 
-@include insights-p-social-share;
-@include insights-p-rtp;
 @include insights-p-card;
+@include insights-p-navigation;
+@include insights-p-rtp;
+@include insights-p-social-share;
 @include insights-p-strips;
 
 // Bug fixes
@@ -26,78 +32,6 @@ $breakpoint-navigation-threshold: 990px;
 /// Vanilla issue https://github.com/vanilla-framework/vanilla-framework/issues/1385
 pre {
   margin-top: 1rem;
-}
-
-/// XXX Navigation dropdown
-/// Temporary implementation of nav dropdown until implemented in Vanilla
-@media (min-width: $breakpoint-navigation-threshold + 1) {
-  .p-navigation__link:hover .hover-menu {
-    display: block;
-    z-index: 10;
-  }
-}
-
-.p-navigation .p-navigation__nav ul li:hover ul::after {
-  @media (min-width: $breakpoint-navigation-threshold + 1) {
-    background: url('https://assets.ubuntu.com/v1/b70e6370-nav-arrow-white.svg') $sp-large bottom no-repeat;
-    content: '';
-    display: block;
-    height: $sp-x-small;
-    left: 0;
-    position: absolute;
-    top: -7px;
-    width: 150px;
-    z-index: 999;
-  }
-}
-
-.hover-menu {
-  display: none;
-
-  @media (min-width: $breakpoint-navigation-threshold + 1) {
-    background: $color-x-light;
-    border: 1px solid $color-mid-light;
-    border-radius: 10px;
-    box-shadow: 0 2px 2px -1px $color-mid-light;
-    display: none;
-    float: none;
-    margin: 0;
-    padding: $sp-x-small 0 $sp-medium;
-    position: absolute;
-    top: 50px;
-    width: 150px;
-    z-index: 1;
-
-    li {
-      font-size: .875rem;
-      padding: $sp-x-small $sp-small 0 $sp-small;
-
-      &:last-child {
-        padding-bottom: 0;
-      }
-    }
-
-    a {
-      color: $color-dark;
-    }
-  }
-}
-
-/// XXX Small screen accordion
-/// Temporary fix until small screen nav accordion implemented in Vanilla
-.p-accordion__tab {
-  background-color: #f7f7f7;
-  font-size: 0.875rem;
-  padding: 1rem 2.5rem 1rem 8px;
-}
-
-.p-accordion__panel {
-  border: none;
-  padding: 0;
-
-  > .p-navigation__links > .p-navigation__link {
-    padding-left: 1rem;
-  }
 }
 
 .design-image {
@@ -121,27 +55,6 @@ pre {
   }
 }
 
-// XXX Caleb - 30.01.18 Nav search box styling fixes
-.p-navigation .p-navigation__nav > .p-search-box {
-  @media (min-width: $breakpoint-navigation-threshold + 1) {
-    margin-top: 2px;
-    max-width: 15rem;
-  }
-}
-
-// XXX Caleb - 30.01.18 Custom hide utilities for navigation breakpoints
-.u-hide--nav-large {
-  @media (min-width: $breakpoint-navigation-threshold + 1) {
-    display: none !important;
-  }
-}
-
-.u-hide--nav-small {
-  @media (max-width: $breakpoint-navigation-threshold) {
-    display: none !important;
-  }
-}
-
 .p-topic-image {
   height: 2.5rem;
 
@@ -150,22 +63,9 @@ pre {
   }
 }
 
-// XXX Ant: 06.02.2018
-// Can be removed when upgrading to vanilla v1.6.6 >
-.p-navigation .p-navigation__link {
-  > a {
-    border-bottom: 3px solid transparent;
-  }
-
-  &.is-selected > a {
-    border-bottom-color: $color-mid-dark;
-  }
-}
-
 .p-post__content {
   max-width: 35em;
 }
-
 
 .link-cta-ubuntu {
   @extend .p-button--positive;

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -4,104 +4,47 @@
   <span class="u-off-screen">
     <a href="#main-content">Jump to main content</a>
   </span>
-  <!-- Mobile nav -->
-  <ul class="p-navigation__links u-hide--nav-large">
-    <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="cloud-tab" role="tab" aria-controls="#cloud" aria-expanded="false">Cloud and Server</button>
-      <div class="p-accordion__panel" id="cloud" role="tabpanel" aria-hidden="true" aria-labelledby="cloud-tab">
-        <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/cloud-and-server">All</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server?category=articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server?category=case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server?category=videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server?category=webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/cloud-and-server?category=white-papers">White papers</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="iot-tab" role="tab" aria-controls="#iot" aria-expanded="false">IoT</button>
-      <div class="p-accordion__panel" id="iot" role="tabpanel" aria-hidden="true" aria-labelledby="iot-tab">
-        <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/internet-of-things">All</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/internet-of-things?category=white-papers">White papers</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="desktop-tab" role="tab" aria-controls="#desktop" aria-expanded="false">Desktop</button>
-      <div class="p-accordion__panel" id="desktop" role="tabpanel" aria-hidden="true" aria-labelledby="desktop-tab">
-        <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/desktop">All</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=articles">Articles</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=case-studies">Case Studies</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=videos">Videos</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=webinars">Webinars</a></li>
-          <li class="p-navigation__link"><a href="/desktop?category=white-papers">White papers</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="p-accordion__group">
-      <button class="p-accordion__tab" id="topics-tab" role="tab" aria-controls="#topics" aria-expanded="false">Topics</button>
-      <div class="p-accordion__panel" id="topics" role="tabpanel" aria-hidden="true" aria-labelledby="topics-tab">
-        <ul class="p-navigation__links">
-          <li class="p-navigation__link"><a href="/topics/design">Design</a></li>
-          <li class="p-navigation__link"><a href="/topics/juju">Juju</a></li>
-          <li class="p-navigation__link"><a href="/topics/maas">MAAS</a></li>
-          <li class="p-navigation__link"><a href="/topics/snappy">Snappy</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="p-navigation__link">
-      <a href="/press-centre">Press centre</a>
-    </li>
-  </ul>
-  <!-- Large screen nav -->
-  <ul class="p-navigation__links u-hide--nav-small">
+  <ul class="p-navigation__links">
     <li class="p-navigation__link{%- if page_slug == 'cloud-and-server' %} is-selected{% endif %}">
       <a href="/cloud-and-server">Cloud and Server</a>
       <ul class="hover-menu">
-        <li><a href="/cloud-and-server">All</a></li>
-        <li><a href="/cloud-and-server?category=articles">Articles</a></li>
-        <li><a href="/cloud-and-server?category=case-studies">Case Studies</a></li>
-        <li><a href="/cloud-and-server?category=videos">Videos</a></li>
-        <li><a href="/cloud-and-server?category=webinars">Webinars</a></li>
-        <li><a href="/cloud-and-server?category=white-papers">White papers</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server">All</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server?category=articles">Articles</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server?category=case-studies">Case Studies</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server?category=videos">Videos</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server?category=webinars">Webinars</a></li>
+        <li class="hover-menu__item"><a href="/cloud-and-server?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'internet-of-things' %} is-selected{% endif %}">
       <a href="/internet-of-things">IoT</a>
       <ul class="hover-menu">
-        <li><a href="/internet-of-things">All</a></li>
-        <li><a href="/internet-of-things?category=articles">Articles</a></li>
-        <li><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
-        <li><a href="/internet-of-things?category=videos">Videos</a></li>
-        <li><a href="/internet-of-things?category=webinars">Webinars</a></li>
-        <li><a href="/internet-of-things?category=white-papers">White papers</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things">All</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things?category=articles">Articles</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things?category=case-studies">Case Studies</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things?category=videos">Videos</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things?category=webinars">Webinars</a></li>
+        <li class="hover-menu__item"><a href="/internet-of-things?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'desktop' %} is-selected{% endif %}">
       <a href="/desktop">Desktop</a>
       <ul class="hover-menu">
-        <li><a href="/desktop">All</a></li>
-        <li><a href="/desktop?category=articles">Articles</a></li>
-        <li><a href="/desktop?category=case-studies">Case Studies</a></li>
-        <li><a href="/desktop?category=videos">Videos</a></li>
-        <li><a href="/desktop?category=webinars">Webinars</a></li>
-        <li><a href="/desktop?category=white-papers">White papers</a></li>
+        <li class="hover-menu__item"><a href="/desktop">All</a></li>
+        <li class="hover-menu__item"><a href="/desktop?category=articles">Articles</a></li>
+        <li class="hover-menu__item"><a href="/desktop?category=case-studies">Case Studies</a></li>
+        <li class="hover-menu__item"><a href="/desktop?category=videos">Videos</a></li>
+        <li class="hover-menu__item"><a href="/desktop?category=webinars">Webinars</a></li>
+        <li class="hover-menu__item"><a href="/desktop?category=white-papers">White papers</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'topics' %} is-selected{% endif %}">
       <a href="#">Topics</a>
       <ul class="hover-menu">
-        <li><a href="/topics/design">Design</a></li>
-        <li><a href="/topics/juju">Juju</a></li>
-        <li><a href="/topics/maas">MAAS</a></li>
-        <li><a href="/topics/snappy">Snapcraft</a></li>
+        <li class="hover-menu__item"><a href="/topics/design">Design</a></li>
+        <li class="hover-menu__item"><a href="/topics/juju">Juju</a></li>
+        <li class="hover-menu__item"><a href="/topics/maas">MAAS</a></li>
+        <li class="hover-menu__item"><a href="/topics/snappy">Snapcraft</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'press-centre' %} is-selected{% endif %}">


### PR DESCRIPTION
## Done

- Separated and consolidated the navigation scss into its own file
- Created a separate settings file for breakpoints/colour etc
- Removed the small-screen nav markup and custom scss (so now there is no accordion dropdown nav on mobile - I removed it because I thought it was unnecessary but I'll be happy to add it back with proper Vanilla styling)
- Fixed visual bugs related to Vanilla 1.7.0-beta-1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8023/
- Check that the navigation links are vertically aligned
- Go to /cloud-and-server
- Hover over Cloud and Server and check that the hover menu appears over top of the grey bar

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1735
Fixes vanilla-framework/vanilla-framework#1737

## Screenshots
### Before
![screenshot_3](https://user-images.githubusercontent.com/25733845/39062655-1b3eb796-44c0-11e8-8a40-4aa953f2b400.png)
![screenshot_4](https://user-images.githubusercontent.com/25733845/39062748-6bba27aa-44c0-11e8-9fbd-0bb2eb478ed8.png)


### After
![screenshot_2](https://user-images.githubusercontent.com/25733845/39062663-2110905e-44c0-11e8-82a3-9640b8e7d343.png)
![screenshot_5](https://user-images.githubusercontent.com/25733845/39062755-6e3761a0-44c0-11e8-84f3-07b718555f5d.png)

