### PR TITLE
Replace open graph thumbnail

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,7 +9,7 @@
       {% if post.featuredmedia %}
         <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
       {% else %}
-        <meta property="og:image" content="https://assets.ubuntu.com/v1/33a3ce22-38018856-02eda0bc-326e-11e8-872e-0b6d5ddb990b.jpg" />
+        <meta property="og:image" content="https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png" />
       {% endif %}
 
       {% if post.link %}


### PR DESCRIPTION
## Done

Replace open graph image

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8023/2018/03/20/lxd-weekly-status-39>
- View source and see that the image referenced in the `og:image` meta tag is [this one](https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png)


## Issue / Card

Fixes #324 
