### PR TITLE
Add some styling to the orange bar

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -238,3 +238,13 @@ pre {
 .u-margin-large--top {
   margin-top: $sp-large !important;
 }
+
+// Marketo insightera-bar-widget styling
+.insightera-bar-content {
+  margin-top: 0;
+  font-size: 14px !important;
+}
+.insightera-content-arrow {
+  position: relative;
+  top: -5px;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -248,3 +248,6 @@ pre {
   position: relative;
   top: -5px;
 }
+.insightera-bar-shadow-bottom {
+  background-image: none !important;
+}


### PR DESCRIPTION
## Done
Add some styling to override Vanilla effecting the orange bar.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- See that the orange bar at the bottom has content and is styled nicely

## Issue / Card
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/331
