### PR TITLE
Fix wrong number of posts displaying on homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,7 +145,7 @@ def homepage():
     sticky_posts, _, _ = helpers.get_formatted_expanded_posts(sticky=True)
     featured_posts = sticky_posts[:3] if sticky_posts else None
     page = helpers.to_int(flask.request.args.get('page'), default=1)
-    posts_per_page = 13 if page == 1 else 12
+    posts_per_page = 12
 
     if category_slug:
         categories = api.get_categories(slugs=[category_slug])
@@ -156,13 +156,9 @@ def homepage():
     posts, total_posts, total_pages = helpers.get_formatted_expanded_posts(
         per_page=posts_per_page,
         category_ids=[category['id']] if category else [],
-        page=page
+        page=page,
+        sticky=False
     )
-
-    if featured_posts:
-        for post in featured_posts:
-            if post in posts:
-                posts.remove(post)
 
     return flask.render_template(
         'index.html',


### PR DESCRIPTION
## Done

Fix bug where two blog posts were missing from homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that all rows of posts are in threes


## Issue / Card

Fixes #334 