### PR TITLE
Only show featured posts on page one

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,9 @@
   </div>
 </section>
 
-{% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
+{% if current_page and current_page == 1 %}
+  {% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
+{% endif %}
 
 {% include "posts.html" %}
 


### PR DESCRIPTION
## Done

Only show featured posts on page one

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that there are featured posts at the top of the page
- Click on any of the pagination links
- If you are not on page one see that there are no featured posts


## Issue / Card

Fixes #333