### PR TITLE
Add some homepage improvements and bug fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,7 +145,7 @@ def homepage():
     sticky_posts, _, _ = helpers.get_formatted_expanded_posts(sticky=True)
     featured_posts = sticky_posts[:3] if sticky_posts else None
     page = helpers.to_int(flask.request.args.get('page'), default=1)
-    posts_per_page = 13 if page == 1 else 12
+    posts_per_page = 12
 
     if category_slug:
         categories = api.get_categories(slugs=[category_slug])

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
   </div>
 </section>
 
-{% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
+{% if featured_posts and current_page == 1 %}{% include "featured-posts.html" %}{% endif %}
 
 {% include "posts.html" %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
   </div>
 </section>
 
-{% if featured_posts and current_page == 1 %}{% include "featured-posts.html" %}{% endif %}
+{% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
 
 {% include "posts.html" %}
 

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -112,7 +112,7 @@
         <h5 class="p-muted-heading">{{ post.group.name }}</h5>
       </header>
       <div class="p-card__content">
-        {% if post.featuredmedia %}
+        {% if post.featuredmedia and post.featuredmedia.code != 'rest_forbidden' %}
         <a href="{{post.link}}">
           <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
         </a>
@@ -121,7 +121,7 @@
         {% if post.author %}
           <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
         {% endif %}
-        {% if not post.featuredmedia %}
+        {% if not post.featuredmedia or post.featuredmedia.code == 'rest_forbidden' %}
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
       </div>


### PR DESCRIPTION
## Done
Add a check for forbidden featured images. Removed the extra post from the homepage. Only show the featured posts on the first page of the homepage.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that there are no posts without images or descriptions
- See that there are now three posts at the end of the page
- Go to the second page and see there is no featured posts

## Issue / Card
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/334
Fixes https://github.com/canonical-websites/insights.ubuntu.com/issues/333