### PR TITLE
Force 16:9 ratio crop for post thumbnails

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -255,8 +255,22 @@ pre {
 // Crop to 16:9
 .u-crop--16-9 {
   position: relative;
-  overflow: hidden;
-  width: 100%;
-  height: 0;
-  padding-bottom: 56.25%;
+
+  &:before {
+    display: block;
+    content: "";
+    width: 100%;
+    padding-top: 56.25%;
+  }
+
+  // Incase img isn't wrapped in a link
+  > a,
+  > img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -273,4 +273,11 @@ pre {
     bottom: 0;
     overflow: hidden;
   }
+
+  > a {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    text-align: center;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -257,5 +257,6 @@ pre {
   position: relative;
   overflow: hidden;
   width: 100%;
-  height: 56.25%;
+  height: 0;
+  padding-bottom: 56.25%;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -251,3 +251,11 @@ pre {
 .insightera-bar-shadow-bottom {
   background-image: none !important;
 }
+
+// Crop to 16:9
+.u-crop--16-9 {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 56.25%;
+}

--- a/templates/alternate_posts.html
+++ b/templates/alternate_posts.html
@@ -43,9 +43,11 @@
     </header>
     <div class="p-card__content">
       {% if post.featuredmedia %}
-      <a href="{{post.link}}">
-        <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
-      </a>
+      <div class="u-crop--16-9">
+        <a href="{{post.link}}">
+          <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
+        </a>
+      </div>
       {% endif %}
       <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
       {% if post.author %}

--- a/templates/featured-posts.html
+++ b/templates/featured-posts.html
@@ -16,9 +16,11 @@
       </header>
       <div class="p-card__content">
         {% if post.featuredmedia %}
-        <a href="{{post.link}}">
-          <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
-        </a>
+        <div class="u-crop--16-9">
+          <a href="{{post.link}}">
+            <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
+          </a>
+        </div>
         {% endif %}
         <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
         {% if post.author %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -113,9 +113,11 @@
       </header>
       <div class="p-card__content">
         {% if post.featuredmedia %}
-        <a href="{{post.link}}">
-          <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
-        </a>
+        <div class="u-crop--16-9">
+          <a href="{{post.link}}">
+            <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
+          </a>
+        </div>
         {% endif %}
         <h3 class="p-heading--four"><a href="{{ post.link }}">{{ post.title.rendered | safe }}</a></h3>
         {% if post.author %}


### PR DESCRIPTION
## Done

Force post thumbnails to be cropped at 16:9

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- See that all post thumbnails are the same ratio and that the headings beneath them are aligned


## Issue / Card

Fixes #328 
