### PR TITLE
Show signup form on first page

### DIFF
--- a/templates/posts.html
+++ b/templates/posts.html
@@ -37,7 +37,7 @@
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">
   {% endif %}
-  {% if loop.index0 == 2 %}
+  {% if loop.index0 == 2 and current_page == 1 %}
   <div class="col-4 p-card--muted">
     <header class="p-card__header">
       <h5 class="p-muted-heading">Newsletter signup</h5>
@@ -47,19 +47,19 @@
         <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
         <div class="p-card--content">
           <ul class="p-list">
-            <li class="p-list__item u-no-margin--top">
+            <li class="p-list__item u-no-margin--top u-clearfix">
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
               <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
             </li>
-            <li class="p-list__item u-no-margin--top">
+            <li class="p-list__item u-no-margin--top u-clearfix">
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
               <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
             </li>
-            <li class="p-list__item u-no-margin--top">
+            <li class="p-list__item u-no-margin--top u-clearfix">
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
               <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
             </li>
-            <li class="p-list__item u-no-margin--top">
+            <li class="p-list__item u-no-margin--top u-clearfix">
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
               <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
             </li>


### PR DESCRIPTION
## Done

- Show sign up form on first page only
- Fix mis-aligned checkboxes on signup form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that the signup form is there
- Go to any other page by clicking the pagination links
- Check that there is no signup form


## Issue / Card

Fixes #340 