### PR TITLE
Improve logic to handle thumbnails

### DIFF
--- a/templates/posts.html
+++ b/templates/posts.html
@@ -112,7 +112,7 @@
         <h5 class="p-muted-heading">{{ post.group.name }}</h5>
       </header>
       <div class="p-card__content">
-        {% if post.featuredmedia %}
+        {% if post.featuredmedia and post.featuredmedia.source_url %}
         <div class="u-crop--16-9">
           <a href="{{post.link}}">
             <img src="{{post.featuredmedia.source_url}}" alt="{{post.featuredmedia.alt_text}}" />
@@ -123,7 +123,7 @@
         {% if post.author %}
           <p><em>By <a href="{{ post.author.link }}" title="More about {{ post.author.name }}">{{ post.author.name }}</a> on {{ post.date }}</em></p>
         {% endif %}
-        {% if not post.featuredmedia %}
+        {% if not post.featuredmedia or not post.featuredmedia.source_url %}
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
       </div>


### PR DESCRIPTION
## Done

Fix issue where featured media is present but no image url

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Look at card with title "On the road to lean infrastructure" and see that it has excerpt text


## Issue / Card

Fixes [#540](https://github.com/ubuntudesign/web-squad/issues/540)
