### PR TITLE
Redirect design article URLs to real articles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 # Core
+import dateutil.parser
 from datetime import datetime
 from urllib.parse import urlparse, urlunparse, unquote
 
@@ -405,10 +406,22 @@ def feed(type=None, slug=None): # noqa
     '/<slug>'
 )
 @app.route(
+    '/<regex("[0-9]{4}"):year>'
+    '/<regex("[0-9]{2}"):month>'
+    '/<slug>'
+)
+@app.route(
     '/webinar/<slug>'
 )
-def post(slug, year=None, month=None, day=None):
+def post(slug, year, month, day=None):
     posts, total_posts, total_pages = helpers.get_formatted_posts(slugs=[slug])
+
+    if not day and posts:
+        pubdate = dateutil.parser.parse(posts[0]['date_gmt'])
+        day = pubdate.day
+        return flask.redirect(
+            '/{year}/{month}/{day}/{slug}'.format(**locals())
+        )
 
     if not posts:
         flask.abort(404)

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,9 +391,9 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-cookie-policy@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-0.0.1.tgz#98d876c0c52282144cdddccff127446a2a65897d"
+cookie-policy@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-1.0.5.tgz#be71abae448c07fe97e5a0b1234d628e835072c3"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
E.g. https://design.canonical.com/2017/10/designing-product-page-templates-for-ubuntu-com/ and https://insights.ubuntu.com/2017/10/10/designing-product-page-templates-for-ubuntu-com.

QA
--

``` bash
$ ./run
$ curl -sI http://0.0.0.0:8023/2017/10/designing-product-page-templates-for-ubuntu-com | grep Location
Location: http://0.0.0.0:8023/2017/10/10/designing-product-page-templates-for-ubuntu-com
```