### PR TITLE
Singularize category names

### DIFF
--- a/templates/alternate_posts.html
+++ b/templates/alternate_posts.html
@@ -57,7 +57,7 @@
       <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
       {% endif %}
     </div>
-    <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+    <p class="p-card__footer">{% include 'singular-category.html' %}</p>
   </div>
   {% if loop.index0 % 3 == 2 or loop.last %}
   </div>

--- a/templates/featured-posts.html
+++ b/templates/featured-posts.html
@@ -34,7 +34,9 @@
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
       </div>
-      <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+      <p class="p-card__footer">
+        {% include 'singular-category.html' %}
+      </p>
     </div>
   {% if loop.index0 % 3 == 2 or loop.last %}
   </div>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -127,7 +127,7 @@
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
       </div>
-      <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+      <p class="p-card__footer">{% include 'singular-category.html' %}</p>
     </div>
   {% endif %}
   {% if loop.index0 % 3 == 2 or loop.last %}

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -29,7 +29,7 @@
             {% endif %}
             <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
           </div>
-          <p class="p-card__footer">{{ post.category.name | capitalize }}</p>
+          <p class="p-card__footer">{% include 'singular-category.html' %}</p>
         </div>
         {%- endfor %}
       </div>

--- a/templates/singular-category.html
+++ b/templates/singular-category.html
@@ -1,9 +1,13 @@
-{% if post.category.name == 'Articles' %}Article{% endif %}
-
-{% if post.category.name == 'Case studies' %}Case study{% endif %}
-
-{% if post.category.name == 'News' %}News{% endif %}
-
-{% if post.category.name == 'Webinars' %}Webinar{% endif %}
-
-{% if post.category.name == 'White papers' %}White paper{% endif %}
+{% if post.category.name == 'Articles' %}
+  Article
+{% elif post.category.name == 'Case studies' %}
+  Case study
+{% elif post.category.name == 'News' %}
+  News
+{% elif post.category.name == 'Webinars' %}
+  Webinar
+{% elif post.category.name == 'White papers' %}
+  White paper
+{% else %}
+  {{ post.category.name }}
+{% endif %}

--- a/templates/singular-category.html
+++ b/templates/singular-category.html
@@ -1,0 +1,9 @@
+{% if post.category.name == 'Articles' %}Article{% endif %}
+
+{% if post.category.name == 'Case studies' %}Case study{% endif %}
+
+{% if post.category.name == 'News' %}News{% endif %}
+
+{% if post.category.name == 'Webinars' %}Webinar{% endif %}
+
+{% if post.category.name == 'White papers' %}White paper{% endif %}


### PR DESCRIPTION
## Done

Show category names as singular rather than plural

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Look at any post card and make sure that the category name is singular rather than plural


## Issue / Card

Fixes [#329](https://github.com/canonical-websites/blog.ubuntu.com/issues/329)