### PR TITLE
Added robots noindex to search results page

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,6 +27,8 @@
       {% endif %}
     {% endif %}
 
+    {% block head_extra %}{% endblock %}
+
     {% if self.title() %}
       <title>{% block title %}{% endblock %} | Ubuntu blog</title>
     {% else %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,5 +1,7 @@
 {% extends "layout.html" %}
 
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block body %}
   <section id="main-content" class="p-strip--accent is-dark is-deep">
     {% if query %}


### PR DESCRIPTION
## Done

- Added robots noindex to search results page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a search](http://0.0.0.0:8023/search?q=juju)
- see `<meta name="robots" content="noindex" />` in the head


## Issue / Card
Fixes #364 