### PR TITLE
Fix the newsletter sign up on the alt homepage

### DIFF
--- a/templates/accordion-signup-form.html
+++ b/templates/accordion-signup-form.html
@@ -12,7 +12,7 @@
         </div>
       </div>
       <section class="p-accordion__panel" id="accordion-form" role="tabpanel" aria-hidden="true" aria-labelledby="accordion-form-tab">
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');"></form>
+        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
           <div class="row">
             <div class="col-12">
               <p>Choose the topics you&rsquo;re interested in</p>
@@ -47,8 +47,11 @@
               <div class="mktFormReq mktField">
                 <label class="u-no-margin--top" for="Email" class="mktolabel u-no-margin--top">Work email: <span>*</span></label>
                 <div class="row">
-                  <div class="col-4">
-                    <input required  id="Email" name="Email" maxlength="255" type="email" class="u-margin-small--top mktoField mktoEmailField  mktoRequired" />
+                  <div class="col-4 u-no-margin--top">
+                    <input required id="Email" name="Email" maxlength="255" type="email" class="u-margin-small--top mktoField mktoEmailField  mktoRequired" />
+                    <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                      <span></span>
+                    </p>
                   </div>
                   <div class="col-8">
                     <div class="u-margin-large--top mktField mktLblRight p-accordion__checkbox">
@@ -62,6 +65,7 @@
               </div>
             </div>
           </div>
+
           <div class="row u-margin-medium--top">
             <div class="col-12">
               <div>In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</div>
@@ -69,6 +73,7 @@
                 <span class="mktoButtonWrap p-card--content">
                   <button type="submit" class="mktoButton">Subscribe now</button>
                 </span>
+                <input type="hidden" name="Consent_to_Processing__c" value="yes" />
                 <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
                 <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
                 <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
@@ -81,20 +86,22 @@
                 <input name="_mkt_disp" value="return" type="hidden">
                 <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
               </div>
-            </form>
-            <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-            <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-            <script>
-              $("#mktoForm_1212").validate({
-                errorPlacement: function(error, element) {
-                  error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-                  error.appendTo( element.addClass( "p-form-validation__input" ));
-                },
-                errorElement: "span",
-                errorClass: "p-form-validation__message"
-              });
-            </script>
-          </section>
+              <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+              <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+              <script>
+                $("#mktoForm_1212").validate({
+                  errorPlacement: function(error, element) {
+                    error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
+                    error.appendTo( element.addClass( "p-form-validation__input" ));
+                  },
+                  errorElement: "span",
+                  errorClass: "p-form-validation__message"
+                });
+              </script>
+            </div>
+          </div>
+        </form>
+      </section>
     </li>
   </ul>
 </div>

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -35,6 +35,7 @@
         <span class="mktoButtonWrap p-card--content">
           <button type="submit" class="mktoButton">Subscribe now</button>
         </span>
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
         <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
         <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -79,6 +79,7 @@
             <span class="mktoButtonWrap p-card--content">
               <button type="submit" class="mktoButton">Subscribe now</button>
             </span>
+            <input type="hidden" name="Consent_to_Processing__c" value="yes" />
             <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
             <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
             <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">


### PR DESCRIPTION
## Done
Fix the newsletter sign up form on the alt homepage. Also, added the consent hidden fields.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/home](http://0.0.0.0:8023/home)
- Open the newsletter accordion 
- Fill out the form and submit
- Check it submits

## Issue / Card
https://github.com/canonical-websites/blog.ubuntu.com/issues/371
