### PR TITLE
Add GDPR copy to post newsletter form

### DIFF
--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -30,11 +30,13 @@
         </div>
         <div class="mktField mktLblRight u-margin-medium--top">
           <span class="mktInput mktLblRight">
-            <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-            <label class="p-form__label u-no-margin--top" for="canonicalUpdatesOptIn">
-              <small>I agree to receive information about Canonical’s products and services.</small>
+            <label>
+              <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+              <span class="p-form__label u-no-margin--top">
+                <small>I agree to receive information about Canonical’s products and services.</small>
+              </span>
+              <span class="mktFormMsg"></span>
             </label>
-            <span class="mktFormMsg"></span>
           </span>
         </div>
         <div class="u-margin-medium--top">

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -8,25 +8,35 @@
       <div class="p-card--content">
         <ul class="p-list">
           <li class="p-list__item u-no-margin--top u-clearfix">
-            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
-            <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
+            <label>
+              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+              <span class="u-no-margin--top">Cloud and server</span>
+            </label>
           </li>
           <li class="p-list__item u-no-margin--top u-clearfix">
-            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
-            <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
+            <label>
+              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+              <span class="u-no-margin--top">Desktop</span>
+            </label>
           </li>
           <li class="p-list__item u-no-margin--top u-clearfix">
-            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
-            <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
+            <label>
+              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+              <span class="u-no-margin--top">Internet of Things</span>
+            </label>
           </li>
           <li class="p-list__item u-no-margin--top u-clearfix">
-            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
-            <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
+            <label>
+              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+              <span class="u-no-margin--top">Tutorials</span>
+            </label>
           </li>
         </ul>
         <div class="mktFormReq mktField u-margin-medium--top">
-          <label class="u-no-margin--top" for="Email" class="mktolabel u-no-margin--top">Work email: <span>*</span></label>
-          <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+          <label>
+            <span class="u-no-margin--top">Work email: <span>*</span></span>
+            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+          </label>
         </div>
         <div class="mktField mktLblRight u-margin-medium--top">
           <span class="mktInput mktLblRight">

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -1,54 +1,64 @@
-<div class="p-card" style="position: sticky; top: 2rem;">
-  <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate">
-    <h3 class="p-card--title p-heading--four">Sign up for email updates</h3>
-    <div class="p-card--content">
-      <p>Choose the topics you're interested in</p>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" {% if post.topic.slug == 'cloud' or 'server'  %} checked="checked"{% endif %} />
-          <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
-        </li>
-        <li class="p-list__item u-no-margin--top">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop"{% if post.topic.slug == 'desktop' %} checked="checked"{% endif %} />
-          <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
-        </li>
-        <li class="p-list__item u-no-margin--top">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things"{% if post.topic.slug == 'internet-of-things' %} checked="checked"{% endif %} />
-          <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
-        </li>
-        <li class="p-list__item u-no-margin--top">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" {% if post.topic.slug == 'tutorials' %} checked="checked" {% endif %}type="checkbox">
-          <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
-        </li>
-      </ul>
-      <div class="mktFormReq mktField">
+<div class="p-card--muted">
+  <header class="p-card__header">
+    <h5 class="p-muted-heading">Newsletter signup</h5>
+  </header>
+  <div class="p-card__content">
+    <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+      <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
+      <div class="p-card--content">
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top u-clearfix">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+            <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
+          </li>
+          <li class="p-list__item u-no-margin--top u-clearfix">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+            <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
+          </li>
+          <li class="p-list__item u-no-margin--top u-clearfix">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+            <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
+          </li>
+          <li class="p-list__item u-no-margin--top u-clearfix">
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+            <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
+          </li>
+        </ul>
+        <div class="mktFormReq mktField u-margin-medium--top">
           <label class="u-no-margin--top" for="Email" class="mktolabel u-no-margin--top">Work email: <span>*</span></label>
-          <input required  id="Email" name="Email" maxlength="255" type="email" class="u-no-margin--top mktoField mktoEmailField  mktoRequired" />
-      </div>
-      <div class="mktField mktLblRight">
-        <span class="mktInput mktLblRight">
-          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-          <label class="p-form__label u-no-margin--top" for="canonicalUpdatesOptIn">I would like to receive occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
-        </span>
-      </div>
-      <div class="u-no-margin--top">
-        <span class="mktoButtonWrap p-card--content">
-          <button type="submit" class="mktoButton">Subscribe now</button>
-        </span>
-        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-        <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
-        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-        <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
-        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-        <input name="kw" value="" type="hidden">
-        <input name="cr" value="" type="hidden">
-        <input name="searchstr" value="" type="hidden">
-        <input name="_mkt_disp" value="return" type="hidden">
-        <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-      </div>
-    </form>
+          <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+        </div>
+        <div class="mktField mktLblRight u-margin-medium--top">
+          <span class="mktInput mktLblRight">
+            <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+            <label class="p-form__label u-no-margin--top" for="canonicalUpdatesOptIn">
+              <small>I agree to receive information about Canonical’s products and services.</small>
+            </label>
+            <span class="mktFormMsg"></span>
+          </span>
+        </div>
+        <div class="u-margin-medium--top">
+          <small>In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</small>
+        </div>
+        <div class="u-margin-medium--top">
+          <span class="mktoButtonWrap p-card--content">
+            <button type="submit" class="mktoButton">Subscribe now</button>
+          </span>
+          <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+          <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+          <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+          <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
+          <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+          <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
+          <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+          <input name="kw" value="" type="hidden">
+          <input name="cr" value="" type="hidden">
+          <input name="searchstr" value="" type="hidden">
+          <input name="_mkt_disp" value="return" type="hidden">
+          <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+        </div>
+      </form>
+    </div>
   </div>
   <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>

--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -42,7 +42,7 @@
         </div>
         <div class="u-margin-medium--top">
           <span class="mktoButtonWrap p-card--content">
-            <button type="submit" class="mktoButton">Subscribe now</button>
+            <button type="submit">Subscribe now</button>
           </span>
           <input type="hidden" name="Consent_to_Processing__c" value="yes" />
           <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">

--- a/templates/post.html
+++ b/templates/post.html
@@ -88,7 +88,7 @@
     <div class="col-4">
       {# right rail #}
       {% include 'product-cards.html' %}
-      {% include 'newsletter-form.html' %}
+      <div style="position: sticky; top: 2rem;">{% include 'newsletter-form.html' %}</div>
     </div>
   </div>
 </div>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -38,76 +38,9 @@
   <div class="row u-equal-height u-clearfix">
   {% endif %}
   {% if loop.index0 == 2 and current_page == 1 %}
-  <div class="col-4 p-card--muted">
-    <header class="p-card__header">
-      <h5 class="p-muted-heading">Newsletter signup</h5>
-    </header>
-    <div class="p-card__content">
-      <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-        <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
-        <div class="p-card--content">
-          <ul class="p-list">
-            <li class="p-list__item u-no-margin--top u-clearfix">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
-              <label class="u-no-margin--top" for="insightscloudserver">Cloud and server</label>
-            </li>
-            <li class="p-list__item u-no-margin--top u-clearfix">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
-              <label class="u-no-margin--top" for="insightsdesktop">Desktop</label>
-            </li>
-            <li class="p-list__item u-no-margin--top u-clearfix">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
-              <label class="u-no-margin--top" for="insightsiot">Internet of Things</label>
-            </li>
-            <li class="p-list__item u-no-margin--top u-clearfix">
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
-              <label class="u-no-margin--top" for="insightstutorials">Tutorials</label>
-            </li>
-          </ul>
-          <div class="mktFormReq mktField u-margin-medium--top">
-              <label class="u-no-margin--top" for="Email" class="mktolabel u-no-margin--top">Work email: <span>*</span></label>
-              <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
-          </div>
-          <div class="mktField mktLblRight u-margin-medium--top">
-            <span class="mktInput mktLblRight">
-              <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-              <label class="p-form__label u-no-margin--top" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label><span class="mktFormMsg"></span>
-            </span>
-          </div>
-          <div>In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</div>
-          <div class="u-margin-medium--top">
-            <span class="mktoButtonWrap p-card--content">
-              <button type="submit" class="mktoButton">Subscribe now</button>
-            </span>
-            <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-            <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-            <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-            <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
-            <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-            <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
-            <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-            <input name="kw" value="" type="hidden">
-            <input name="cr" value="" type="hidden">
-            <input name="searchstr" value="" type="hidden">
-            <input name="_mkt_disp" value="return" type="hidden">
-            <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-          </div>
-        </form>
-        </div>
-      </div>
-      <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-      <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-      <script>
-        $("#mktoForm_1212").validate({
-          errorPlacement: function(error, element) {
-            error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-            error.appendTo( element.addClass( "p-form-validation__input" ));
-          },
-          errorElement: "span",
-          errorClass: "p-form-validation__message"
-        });
-      </script>
-    </div>
+  <div class="col-4">
+    {% include 'newsletter-form.html' %}
+  </div>
   {% else %}
     <div class="col-4 p-card--post">
       <header class="p-card__header--{{ post.group.slug }}">


### PR DESCRIPTION
## Done

- Add GDPR copy to newsletter form on blog post page
- Made form an include so is the same across both pages 
- Fix button style conflict 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Go to a blog post and make sure the newsletter form is the same as the one on the homepage
- Go to <http://0.0.0.0:8023/2018/04/16/botsandus-build-a-social-robot-on-ubuntu> and make sure the newsletter form button looks correct

## Issue / Card

Fixes #378 
Fixes #308 
