### PR TITLE
For the 'snapcraft.io' tag, set a canonical meta tag

### DIFF
--- a/app.py
+++ b/app.py
@@ -450,11 +450,19 @@ def post(slug, year, month, day=None):
         exclude=post['id']
     )
 
+    snapcraft_io_tag = list(filter(lambda tag: tag['id'] == 2996, tags))
+
+    if snapcraft_io_tag:
+        canonical_link = 'https://snapcraft.io/blog/' + slug
+    else:
+        canonical_link = None
+
     return flask.render_template(
         'post.html',
         post=post,
         tags=tags,
         related_posts=related_posts,
+        canonical_link=canonical_link,
     )
 
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,6 +27,10 @@
       {% endif %}
     {% endif %}
 
+    {% if canonical_link %}
+      <link rel="canonical" href="{{ canonical_link }}" />
+    {% endif %}
+
     {% block head_extra %}{% endblock %}
 
     {% if self.title() %}


### PR DESCRIPTION
## Done

- Set `<link rel="canonical" href="url" />` for posts with `snapcraft.io` tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/2017/09/11/top-10-snaps-in-august](http://0.0.0.0:8023/2017/09/11/top-10-snaps-in-august)
- View source and ensure the `<link>` elemenet is present in the `<head>` of the document


## Issue / Card

Fixes https://github.com/CanonicalLtd/snap-squad/issues/598


## Note

Advice welcomed regarding a better approach to defining the 'magic id' etc.
