### PR TITLE
Add card header style for tutorials and description to first two cards

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -113,6 +113,11 @@
       @extend %post-card-header;
       border-top: 3px solid #48929b;
     }
+
+    &--tutorials {
+      @extend %post-card-header;
+      border-top: 3px solid #47919e;
+    }
   }
 
   .p-card__date {

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -63,7 +63,7 @@
         {% endif %}
         {% if current_page == 1 %}
           {% if loop.index0 == 0 or loop.index0 == 1 %}
-            <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
+            <p class="u-no-padding--bottom u-hide--small">{{ post.summary | striptags | urlize(30, true) }}</p>
           {% endif %}
         {% endif %}
       </div>

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -61,6 +61,11 @@
         {% if not post.featuredmedia or not post.featuredmedia.source_url %}
         <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
         {% endif %}
+        {% if current_page == 1 %}
+          {% if loop.index0 == 0 or loop.index0 == 1 %}
+            <p class="u-no-padding--bottom">{{ post.summary | striptags | urlize(30, true) }}</p>
+          {% endif %}
+        {% endif %}
       </div>
       <p class="p-card__footer">{% include 'singular-category.html' %}</p>
     </div>


### PR DESCRIPTION
## Done

- Add card header style for tutorials
- Add description to first two cards

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- See that any cards in the tutorials category have a header style inline with the other cards
- See that the first two posts on page 1 only have summaries


## Issue / Card

Fixes #387 