### PR TITLE
Filter out snapcraft tags

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,17 +416,20 @@ def post(slug, year, month, day=None):
         exclude=post['id']
     )
 
+    # Even though we're filtering tags below, we need to know the snapcraft.io
+    # tag, specifically to add the canonical meta tag
     snapcraft_io_tag = list(filter(lambda tag: tag['id'] == 2996, tags))
-
     if snapcraft_io_tag:
         canonical_link = 'https://snapcraft.io/blog/' + slug
     else:
         canonical_link = None
 
+    display_tags = helpers.filter_tags_for_display(tags)
+
     return flask.render_template(
         'post.html',
         post=post,
-        tags=tags,
+        tags=display_tags,
         related_posts=related_posts,
         canonical_link=canonical_link,
     )

--- a/helpers.py
+++ b/helpers.py
@@ -212,6 +212,20 @@ def to_int(value_to_convert, default=None):
         return default
 
 
+def filter_tags_for_display(tags):
+    """
+    Filter out specific tags to remove noise
+
+    :param tags: list of wordpress tags
+    :return: list of wordpress tags
+    """
+    # snapcraft tags
+    def is_snapcraft(tag):
+        return tag['name'].startswith('sc:')
+
+    return [tag for tag in tags if not is_snapcraft(tag)]
+
+
 class RegexConverter(werkzeug.routing.BaseConverter):
     def __init__(self, url_map, *items):
         super(RegexConverter, self).__init__(url_map)


### PR DESCRIPTION
## Done

Stop out any tag that starts with `sc:` being displayed. We're using this format to make the snapcraft.io experience richer and don't want to clutter blog.ubuntu.com pages.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Visit a snapcraft related post http://0.0.0.0:8023/2018/08/07/fresh-snaps-from-july-2018 for example
- Check that there are no tags displayed in the heading, and compare to the live version of the page https://blog.ubuntu.com/2018/08/07/fresh-snaps-from-july-2018
- Check other posts that have tags, that they still display


## Issue / Card
Fixes https://github.com/CanonicalLtd/snap-squad/issues/684
