### PR TITLE
lossy cloudinary optimisation

### DIFF
--- a/templates/featured-posts.html
+++ b/templates/featured-posts.html
@@ -18,10 +18,10 @@
         {% if post.featuredmedia %}
         <div class="u-crop--16-9">
           <a href="{{post.link}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured post', 'eventAction' : 'from:https://blog.ubuntu.com, to:https://blog.ubuntu.com{{post.link}}', 'eventLabel' : '{{ post.title.rendered | safe }}', 'eventValue' : undefined });">
-            <img src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}}"
-              srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}} 460w,
-                      https://res.cloudinary.com/canonical/image/fetch/w_620/{{post.featuredmedia.source_url}} 620w,
-                      https://res.cloudinary.com/canonical/image/fetch/w_875/{{post.featuredmedia.source_url}} 875w"
+            <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+              srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
+                      https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
+                      https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"
               sizes="(min-width: 1031px) 460px,
                     (max-width: 1030px) and (min-width: 876px) 460px,
                     (max-width: 875px) and (min-width: 621px) 875px,

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -50,10 +50,10 @@
         {% if post.featuredmedia and post.featuredmedia.source_url %}
         <div class="u-crop--16-9">
           <a href="{{post.link}}">
-            <img src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}}"
-            srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}} 460w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_620/{{post.featuredmedia.source_url}} 620w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_875/{{post.featuredmedia.source_url}} 875w"
+            <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+            srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"
             sizes="(min-width: 1031px) 460px,
                     (max-width: 1030px) and (min-width: 876px) 460px,
                     (max-width: 875px) and (min-width: 621px) 875px,

--- a/templates/upcoming_posts.html
+++ b/templates/upcoming_posts.html
@@ -14,10 +14,10 @@
       {% if post.featuredmedia and post.featuredmedia.source_url %}
       <div class="u-crop--16-9">
         <a href="{{post.link}}">
-          <img src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}}"
-            srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}} 460w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_620/{{post.featuredmedia.source_url}} 620w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_875/{{post.featuredmedia.source_url}} 875w"
+          <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+            srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"
             sizes="(min-width: 1031px) 460px,
                     (max-width: 1030px) and (min-width: 876px) 460px,
                     (max-width: 875px) and (min-width: 621px) 875px,

--- a/templates/whats-coming-up.html
+++ b/templates/whats-coming-up.html
@@ -19,10 +19,10 @@
       {% if post.featuredmedia %}
       <div class="u-crop--16-9">
         <a href="{{post.link}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Upcoming event', 'eventAction' : 'from:https://blog.ubuntu.com, to:https://blog.ubuntu.com{{post.link}}', 'eventLabel' : '{{ post.title.rendered | safe }}', 'eventValue' : undefined });">
-          <img src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}}"
-            srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{post.featuredmedia.source_url}} 460w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_620/{{post.featuredmedia.source_url}} 620w,
-                    https://res.cloudinary.com/canonical/image/fetch/w_875/{{post.featuredmedia.source_url}} 875w"
+          <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+            srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
+                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"
             sizes="(min-width: 1031px) 460px,
                     (max-width: 1030px) and (min-width: 876px) 460px,
                     (max-width: 875px) and (min-width: 621px) 875px,


### PR DESCRIPTION
## Done

cloudinary suggested to use two flags ```q_auto,f_auto``` to substantially reduce the size of jpegs and pngs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- compare the size of various pages from your version and live

