### PR TITLE
Removed google plus from articles and press centre

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -52,11 +52,6 @@
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--google" title="Share on google+" href="https://plus.google.com/share?url=https://blog.ubuntu.com/?p={{ post.id }}">
-          Google+
-        </a>
-        </li>
-        <li class="p-inline-list__item">
           <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe }}">
           LinkedIn
         </a>

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -52,10 +52,6 @@
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item"><a href="https://www.facebook.com/ubuntulinux" title="Follow us on facebook">Ubuntu</a></li>
           </ul>
-          <h5 class="p-muted-heading">Google+</h5>
-          <ul class="p-inline-list--middot">
-            <li class="p-inline-list__item"><a href="https://plus.google.com/+Ubuntu/posts" title="Follow us on Google+">Ubuntu</a></li>
-          </ul>
           <h5 class="p-muted-heading">YouTube</h5>
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item"><a href="http://www.youtube.com/celebrateubuntu" title="Follow us on YouTube">Celebrate Ubuntu</a></li>


### PR DESCRIPTION
## Done

- google is closing google+, removed the links from articles and the press centre

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [article](http://0.0.0.0:8023/2018/10/03/fing-iot-network-monitoring) and [press centre](http://0.0.0.0:8023/press-centre)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #412

## Screenshots

article
![image](https://user-images.githubusercontent.com/441217/46677075-c4821000-cbd9-11e8-9e54-78c7075e99dc.png)


press centre
![image](https://user-images.githubusercontent.com/441217/46677042-b0d6a980-cbd9-11e8-9514-a76ea684d1a8.png)

