### PR TITLE
Added cloudinary to images inside a post content

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -105,11 +105,16 @@ def format_post(post):
         )
 
     if post['content']:
-        CLOUDINARY = "https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,"
+        CLOUDINARY = ('https://res.cloudinary.com/'
+            'canonical/image/fetch/q_auto,f_auto,')
         post['content']['rendered'] = re.sub(
             r'img(.*)src=\"(.[^\"]*)\"',
-            r'img\1 src="{url}w_560/\2"  srcset="{url}w_375/\2 375w, {url}w_480/\2 480w, {url}w_560/\2 560w" sizes="(max-width: 375px) 280px, (max-width: 480px) 440px, 560px"'.format(
-                url=CLOUDINARY),
+            r'img\1 src="{url}w_560/\2"'
+                r'srcset="{url}w_375/\2 375w,'
+                r'{url}w_480/\2 480w, {url}w_560/\2 560w"'
+                r'sizes="(max-width: 375px) 280px,'
+                r'(max-width: 480px) 440px,'
+                r'560px"'.format(url=CLOUDINARY),
             post['content']['rendered'])
 
     return post

--- a/helpers.py
+++ b/helpers.py
@@ -104,6 +104,14 @@ def format_post(post):
             post['_end_day'], end_month_name, post['_end_year']
         )
 
+    if post['content']:
+        CLOUDINARY = "https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,"
+        post['content']['rendered'] = re.sub(
+            r'img(.*)src=\"(.[^\"]*)\"',
+            r'img\1 src="{url}w_560/\2"  srcset="{url}w_375/\2 375w, {url}w_480/\2 480w, {url}w_560/\2 560w" sizes="(max-width: 375px) 280px, (max-width: 480px) 440px, 560px"'.format(
+                url=CLOUDINARY),
+            post['content']['rendered'])
+
     return post
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -37,18 +37,15 @@ def get_formatted_expanded_posts(**kwargs):
 
     force_group = None
 
-    if kwargs.get('group_ids'):
-        force_group = kwargs.get('group_ids')[0]
+    if kwargs.get("group_ids"):
+        force_group = kwargs.get("group_ids")[0]
 
     for post in posts:
         post = format_post(post)
 
-        post['group'] = get_first_group(
-            post.get('group', ''),
-            force_group=force_group
-        )
+        post["group"] = get_first_group(post.get("group", ""), force_group=force_group)
 
-        post['category'] = get_first_category(post['categories'])
+        post["category"] = get_first_category(post["categories"])
 
     return posts, total_posts, total_pages
 
@@ -83,39 +80,39 @@ def format_post(post):
     - Making the link relative
     """
 
-    if 'author' in post['_embedded'] and post['_embedded']['author']:
-        post['author'] = post['_embedded']['author'][0]
-        post['author']['link'] = urlsplit(
-            post['author']['link']
-        ).path.rstrip('/')
-    post['link'] = urlsplit(post['link']).path.rstrip('/')
-    post['summary'] = format_summary(post['excerpt']['rendered'])
-    post['date'] = format_date(post['date'])
+    if "author" in post["_embedded"] and post["_embedded"]["author"]:
+        post["author"] = post["_embedded"]["author"][0]
+        post["author"]["link"] = urlsplit(post["author"]["link"]).path.rstrip("/")
+    post["link"] = urlsplit(post["link"]).path.rstrip("/")
+    post["summary"] = format_summary(post["excerpt"]["rendered"])
+    post["date"] = format_date(post["date"])
 
-    if post['_start_month']:
-        start_month_name = get_month_name(int(post['_start_month']))
-        post['start_date'] = '{} {} {}'.format(
-           post['_start_day'], start_month_name, post['_start_year']
+    if post["_start_month"]:
+        start_month_name = get_month_name(int(post["_start_month"]))
+        post["start_date"] = "{} {} {}".format(
+            post["_start_day"], start_month_name, post["_start_year"]
         )
 
-    if post['_end_month']:
-        end_month_name = get_month_name(int(post['_end_month']))
-        post['end_date'] = '{} {} {}'.format(
-            post['_end_day'], end_month_name, post['_end_year']
+    if post["_end_month"]:
+        end_month_name = get_month_name(int(post["_end_month"]))
+        post["end_date"] = "{} {} {}".format(
+            post["_end_day"], end_month_name, post["_end_year"]
         )
 
-    if post['content']:
-        CLOUDINARY = ('https://res.cloudinary.com/'
-            'canonical/image/fetch/q_auto,f_auto,')
-        post['content']['rendered'] = re.sub(
-            r'img(.*)src=\"(.[^\"]*)\"',
+    if post["content"]:
+        CLOUDINARY = (
+            "https://res.cloudinary.com/" "canonical/image/fetch/q_auto,f_auto,"
+        )
+        post["content"]["rendered"] = re.sub(
+            r"img(.*)src=\"(.[^\"]*)\"",
             r'img\1 src="{url}w_560/\2"'
-                r'srcset="{url}w_375/\2 375w,'
-                r'{url}w_480/\2 480w, {url}w_560/\2 560w"'
-                r'sizes="(max-width: 375px) 280px,'
-                r'(max-width: 480px) 440px,'
-                r'560px"'.format(url=CLOUDINARY),
-            post['content']['rendered'])
+            r'srcset="{url}w_375/\2 375w,'
+            r'{url}w_480/\2 480w, {url}w_560/\2 560w"'
+            r'sizes="(max-width: 375px) 280px,'
+            r"(max-width: 480px) 440px,"
+            r'560px"'.format(url=CLOUDINARY),
+            post["content"]["rendered"],
+        )
 
     return post
 
@@ -126,7 +123,7 @@ def get_month_name(month_index):
     January
     """
 
-    return datetime.date(1900, month_index, 1).strftime('%B')
+    return datetime.date(1900, month_index, 1).strftime("%B")
 
 
 def format_date(date):
@@ -135,7 +132,7 @@ def format_date(date):
     1 January 2017
     """
 
-    return dateutil.parser.parse(date).strftime('%-d %B %Y')
+    return dateutil.parser.parse(date).strftime("%-d %B %Y")
 
 
 def format_summary(excerpt):
@@ -171,7 +168,7 @@ def join_ids(ids):
     - including casting all types to a string
     """
 
-    return ','.join([str(item) for item in ids])
+    return ",".join([str(item) for item in ids])
 
 
 def build_url(base_url, endpoint, parameters):
@@ -192,7 +189,7 @@ def build_url(base_url, endpoint, parameters):
     if parameters:
         query_string = "?" + urlencode(parameters)
 
-    return base_url.rstrip('/') + '/' + endpoint.lstrip('/') + query_string
+    return base_url.rstrip("/") + "/" + endpoint.lstrip("/") + query_string
 
 
 def ignore_warnings(warning_to_ignore):
@@ -234,7 +231,7 @@ def filter_tags_for_display(tags):
     """
     # snapcraft tags
     def is_snapcraft(tag):
-        return tag['name'].startswith('sc:')
+        return tag["name"].startswith("sc:")
 
     return [tag for tag in tags if not is_snapcraft(tag)]
 

--- a/helpers.py
+++ b/helpers.py
@@ -43,7 +43,9 @@ def get_formatted_expanded_posts(**kwargs):
     for post in posts:
         post = format_post(post)
 
-        post["group"] = get_first_group(post.get("group", ""), force_group=force_group)
+        post["group"] = get_first_group(
+            post.get("group", ""), force_group=force_group
+        )
 
         post["category"] = get_first_category(post["categories"])
 
@@ -82,7 +84,9 @@ def format_post(post):
 
     if "author" in post["_embedded"] and post["_embedded"]["author"]:
         post["author"] = post["_embedded"]["author"][0]
-        post["author"]["link"] = urlsplit(post["author"]["link"]).path.rstrip("/")
+        post["author"]["link"] = urlsplit(post["author"]["link"]).path.rstrip(
+            "/"
+        )
     post["link"] = urlsplit(post["link"]).path.rstrip("/")
     post["summary"] = format_summary(post["excerpt"]["rendered"])
     post["date"] = format_date(post["date"])
@@ -101,7 +105,8 @@ def format_post(post):
 
     if post["content"]:
         CLOUDINARY = (
-            "https://res.cloudinary.com/" "canonical/image/fetch/q_auto,f_auto,"
+            "https://res.cloudinary.com/"
+            "canonical/image/fetch/q_auto,f_auto,"
         )
         post["content"]["rendered"] = re.sub(
             r"img(.*)src=\"(.[^\"]*)\"",

--- a/templates/post.html
+++ b/templates/post.html
@@ -42,17 +42,17 @@
           Share on:
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered }}&amp;p[summary]={{ post.summary }}%26hellip%3B&amp;p[images][0]=">
+          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered | safe | urlencode }}&amp;p[summary]={{ post.summary | safe | urlencode}}%26hellip%3B&amp;p[images][0]={{ post.featuredmedia.source_url }}">
             Facebook
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe }}&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;hashtags=ubuntu">
+          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe | urlencode }}&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;hashtags=ubuntu">
             Twitter
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe }}">
+          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe | urlencode }}">
           LinkedIn
         </a>
         </li>

--- a/templates/post.html
+++ b/templates/post.html
@@ -42,7 +42,7 @@
           Share on:
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered | safe | urlencode }}&amp;p[summary]={{ post.summary | safe | urlencode}}%26hellip%3B&amp;p[images][0]={{ post.featuredmedia.source_url }}">
+          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered | safe | urlencode }}&amp;p[summary]={{ post.summary | safe | urlencode}}%26hellip%3B&amp;p[images][0]=">
             Facebook
           </a>
         </li>


### PR DESCRIPTION
## Done

- Added cloudinary to images inside a post content
- urlencoded post titles and summaries for sharing links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Compare some [live site pages](https://blog.ubuntu.com/2018/07/17/get-productive-on-the-linux-desktop-with-7-essential-apps) 6.3M size to the [demo](http://0.0.0.0:8023/2018/07/17/get-productive-on-the-linux-desktop-with-7-essential-apps) 1.6M and some others
- Make sure no pages are missing images
- See that sharing links have urlencoded links and facebook now has an image url

