### PR TITLE
Remove double cloudinary urls from images

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -108,6 +108,18 @@ def format_post(post):
             "https://res.cloudinary.com/"
             "canonical/image/fetch/q_auto,f_auto,"
         )
+        """
+        Remove existing cloudinary urls
+        """
+        post["content"]["rendered"] = re.sub(
+            r'img(.*)src="https://res.cloudinary.com/canonical'
+            r'(.[^http]*)/http(.[^"]*)"',
+            r'img\1 src="\3"',
+            post["content"]["rendered"],
+        )
+        """
+        Add cloudinary urls with a srcset
+        """
         post["content"]["rendered"] = re.sub(
             r"img(.*)src=\"(.[^\"]*)\"",
             r'img\1 src="{url}w_560/\2"'


### PR DESCRIPTION
## Done

- Remove double cloudinary urls from images... for example:

this

```
https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_560/https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_560/https://admin.insights.ubuntu.com/wp-content/uploads/7fd1/Snapcraft-Infographic-EndUser.jpg
```

becomes

```
https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_560/https://admin.insights.ubuntu.com/wp-content/uploads/7fd1/Snapcraft-Infographic-EndUser.jpg
```

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Compare the image url for the main image
[demo](http://0.0.0.0:8023/2018/10/18/infographic-snaps-in-numbers) vs [live](https://blog.ubuntu.com/2018/10/18/infographic-snaps-in-numbers)

