### PR TITLE
Fix errors for missing day, month and year in URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -389,18 +389,21 @@ def feed(type=None, slug=None): # noqa
 @app.route(
     '/webinar/<slug>'
 )
-def post(slug, year, month, day=None):
+def post(slug, year=None, month=None, day=None):
     posts, total_posts, total_pages = helpers.get_formatted_posts(slugs=[slug])
-
-    if not day and posts:
-        pubdate = dateutil.parser.parse(posts[0]['date_gmt'])
-        day = pubdate.strftime('%d')
-        return flask.redirect(
-            '/{year}/{month}/{day}/{slug}'.format(**locals())
-        )
 
     if not posts:
         flask.abort(404)
+
+    if not (day and month and year):
+        pubdate = dateutil.parser.parse(posts[0]['date_gmt'])
+        day = pubdate.strftime('%d')
+        month = pubdate.strftime('%m')
+        year = pubdate.strftime('%Y')
+
+        return flask.redirect(
+            '/{year}/{month}/{day}/{slug}'.format(**locals())
+        )
 
     post = posts[0]
 


### PR DESCRIPTION
We are getting errors like this one, in the logs and [in sentry](https://sentry.is.canonical.com/canonical/blog-ubuntu-com/issues/57/):

```
[2018-10-29 08:49:49,152] ERROR in app: Exception on /webinar/ubuntu-whats-the-security-story [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
TypeError: post() missing 2 required positional arguments: 'year' and 'month'
```

This fixes these errors.

QA
--

`./run` and go to e.g. http://0.0.0.0:8023/webinars/ubuntu-whats-the-security-story, see that you're redirected to http://0.0.0.0:8023/2017/12/02/ubuntu-whats-the-security-story, which loads without error.