### PR TITLE
Gracefully handle missing "from_cache"

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -115,7 +115,7 @@ def cached_request(url):
         ).inc()
         raise request_error
 
-    if response.from_cache:
+    if hasattr(response, 'from_cache') and response.from_cache:
         requested_from_cache_counter.labels(
             domain=urlparse(url).netloc,
         ).inc()


### PR DESCRIPTION
We have got errors like this in the logs:

```
2018-10-29 08:04:31.042Z ERROR flask.app "Exception on /archives [GET]" request_id=d7b611720f02c2e62ebc57e9bdb3f60e
Traceback (most recent call last):                            
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()                                                                                                       
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)                                              
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)                                                             
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 35, in reraise
    raise value                                                                                  
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()                                                     
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)                                   
  File "/srv/app.py", line 343, in archives
    category_ids=category_ids if category_ids else [],                                      
  File "/srv/helpers.py", line 22, in get_formatted_posts     
    posts, total_posts, total_pages = api.get_posts(**kwargs)                
  File "/srv/api.py", line 96, in get_posts                                                                                           
    'exclude': exclude                                                                    
  File "/srv/api.py", line 34, in get                                                                                                                                                                                  helpers.build_url(API_URL, endpoint, parameters)                                                                                                                                                              
  File "/srv/feeds.py", line 118, in cached_request
    if response.from_cache:
```

I'm not sure why this is, and I can't reproduce it locally. `from_cache` should always exist [on a requests_cache Response](https://requests-cache.readthedocs.io/en/latest/user_guide.html).

It may be to do with our use of [HTTPAdapter for doing retries](https://github.com/canonical-websites/blog.ubuntu.com/blob/master/feeds.py#L44) - so maybe when this kicks in and a connection is retried, we end up with a regular requests Response, which is missing the `from_cache` property.

Anyway, here I'm simply checking for the existence of the `from_cache` property before trying to use it. If it's missing we treat it as if it were `False`, which is probably accurate. At least it would be in the scenario of my hypothesis above.

QA
--

I can't reproduce the error locally, so I don't know how to QA the failure case. But you can QA the normal case by simply running the site with `./run --env FLASK_DEBUG=`, browsing around, and checking you don't see any errors.