### PR TITLE
Add access logs to blog

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent app:app --bind $1 --worker-class gevent --name talisker-`hostname` --access-logfile -"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"


### PR DESCRIPTION
## Done

Add access logs to blog to let get gunicorn prometheus data 

## QA

- Check out this feature branch
- add `TALISKER_NETWORKS=172.17.0.1` to `.env`
- `./run`
- access a page http://0.0.0.0:8023/
- http://0.0.0.0:8023/_status/metrics
- make sure you have some gunicorn metrics