### PR TITLE
Performance speed-ups and better meta data

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -121,8 +121,8 @@ def format_post(post):
         Add cloudinary urls with a srcset
         """
         post["content"]["rendered"] = re.sub(
-            r"img(.*)src=\"(.[^\"]*)\"",
-            r'img\1 src="{url}w_560/\2"'
+            r"img(.*) src=\"(.[^\"]*)\"",
+            r'img\1 decoding="async" src="{url}w_560/\2"'
             r'srcset="{url}w_375/\2 375w,'
             r'{url}w_480/\2 480w, {url}w_560/\2 560w"'
             r'sizes="(max-width: 375px) 280px,'

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -5,11 +5,13 @@
     <div class="row">
       <div class="col-10">
         <h1>
-          {% if group %}
-            {{ group.name }} archives
-          {% else %}
-            Archives
-          {% endif %}
+          {% block title %}
+            {% if group %}
+              {{ group.name }} archives
+            {% else %}
+              Archives
+            {% endif %}
+          {% endblock %}
         </h1>
         <p>
           {{ total_posts }}

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}{{ author.name }}{% endblock %}
+{% block description %}{% if author.id == 217 %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% else %}{{ author.description | safe }}{% endif %}{% endblock %}
 {% block body %}
 <div class="p-strip">
   <div class="row">

--- a/templates/cloud-and-server.html
+++ b/templates/cloud-and-server.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Cloud and Server{% endblock %}
+{#% block description %}All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.{% endblock %#}
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg')">

--- a/templates/cloud-and-server.html
+++ b/templates/cloud-and-server.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block title %}Cloud and Server{% endblock %}
-{#% block description %}All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.{% endblock %#}
+{% block description %}All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.{% endblock %}
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg')">

--- a/templates/desktop.html
+++ b/templates/desktop.html
@@ -1,4 +1,7 @@
 {% extends "layout.html" %}
+{% block title %}Desktop{% endblock %}
+{% block description %}All you need to know about the fast, free and user-friendly Ubuntu desktop operating system.{% endblock %}
+
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/bf5e5af8-desktop-overview-hero.jpg')">

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}{{ group_details.name }}{% endblock %}
+{% block description %}{{ group_details.description | safe }}{% endblock %}
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('{{ group_details.hero_url }}')">

--- a/templates/internet-of-things.html
+++ b/templates/internet-of-things.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Internet of Things{% endblock %}
+{% block description %}All you need to know about building and managing IoT and embedded devices using Ubuntu.{% endblock %}
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/d1d58769-drone-iceland-unsplash-no-logo.jpg')">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,6 +16,20 @@
     })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
     <!-- End Google Tag Manager -->
 
+    {% if post and post.title %}
+      <title>{{post.title.rendered | safe}} | Ubuntu blog</title>
+      <meta property="og:title" content="{{post.title.rendered | safe}}" />
+    {% elif self.title and self.title() %}
+      <title>{{ self.title() }} | Ubuntu blog</title>
+      <meta property="og:title" content="{{ self.title() }} | Ubuntu blog" />
+    {% else %}
+      <title>Ubuntu blog</title>
+      <meta property="og:title" content="Ubuntu blog" />
+    {% endif %}
+
+      <meta name="description" content="{% block description %}Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.{% endblock %}" />
+      <meta property="og:description" content="{{ self.description() }}" />
+
     {% if post and post.featuredmedia %}
       <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
     {% else %}
@@ -23,26 +37,7 @@
     {% endif %}
 
     {% if post and post.link %}
-      <meta property="og:url" content="{{post.link}}" />
-    {% endif %}
-
-    {% if post and post.summary %}
-      <meta name="description" content="{{post.summary | striptags}}" />
-      <meta property="og:description" content="{{post.summary | striptags}}" />
-    {% else %}
-      <meta name="description" content="{% block description %}Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.{% endblock %}" />
-      <meta property="og:description" content="{{ self.description() }}" />
-    {% endif %}
-
-    {% if post and post.title %}
-      <title>{{post.title.rendered | safe}} | Ubuntu blog</title>
-      <meta property="og:title" content="{{post.title.rendered | safe}}" />
-    {% elif self.title and self.title() %}
-      <title>{% block title %}{% endblock %} | Ubuntu blog</title>
-      <meta property="og:title" content="{{self.title.rendered | safe}} | Ubuntu blog" />
-    {% else %}
-      <title>Ubuntu blog</title>
-      <meta property="og:title" content="Ubuntu blog" />
+      <meta property="og:url" content="https://blog.ubuntu.com{{post.link}}" />
     {% endif %}
 
     {% if canonical_link %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,39 +16,43 @@
     })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
     <!-- End Google Tag Manager -->
 
-    {% if post %}
-      {% if post.featuredmedia %}
-        <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
-      {% else %}
-        <meta property="og:image" content="https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png" />
-      {% endif %}
+    {% if post and post.featuredmedia %}
+      <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
+    {% else %}
+      <meta property="og:image" content="https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png" />
+    {% endif %}
 
-      {% if post.link %}
-        <meta property="og:url" content="{{post.link}}" />
-      {% endif %}
+    {% if post and post.link %}
+      <meta property="og:url" content="{{post.link}}" />
+    {% endif %}
 
-      {% if post.summary %}
-        <meta property="og:description" content="{{post.summary | striptags}}" />
-      {% endif %}
+    {% if post and post.summary %}
+      <meta name="description" content="{{post.summary | striptags}}" />
+      <meta property="og:description" content="{{post.summary | striptags}}" />
+    {% else %}
+      <meta name="description" content="{% block description %}Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.{% endblock %}" />
+      <meta property="og:description" content="{{ self.description() }}" />
+    {% endif %}
 
-      {% if post.title %}
-        <meta property="og:title" content="{{post.title.rendered | safe}}" />
-      {% else %}
-        <meta property="og:title" content="Ubuntu blog" />
-      {% endif %}
+    {% if post and post.title %}
+      <title>{{post.title.rendered | safe}} | Ubuntu blog</title>
+      <meta property="og:title" content="{{post.title.rendered | safe}}" />
+    {% elif self.title and self.title() %}
+      <title>{% block title %}{% endblock %} | Ubuntu blog</title>
+      <meta property="og:title" content="{{self.title.rendered | safe}} | Ubuntu blog" />
+    {% else %}
+      <title>Ubuntu blog</title>
+      <meta property="og:title" content="Ubuntu blog" />
     {% endif %}
 
     {% if canonical_link %}
       <link rel="canonical" href="{{ canonical_link }}" />
     {% endif %}
 
-    {% block head_extra %}{% endblock %}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@ubuntu" />
 
-    {% if self.title() %}
-      <title>{% block title %}{% endblock %} | Ubuntu blog</title>
-    {% else %}
-      <title>Ubuntu blog</title>
-    {% endif %}
+    {% block head_extra %}{% endblock %}
 
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
@@ -110,10 +114,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
       </footer>
     </div>
-    <script src="/static/js/modules/cookie-policy.js"></script>
-    <script src="/static/js/aria-controls.js"></script>
-    <script src="/static/js/search.js"></script>
-    <script src="/static/js/modules/global.js"></script>
+    <script src="/static/js/modules/cookie-policy.js" async></script>
+    <script src="/static/js/aria-controls.js" async></script>
+    <script src="/static/js/search.js" async></script>
+    <script src="/static/js/modules/global.js" async></script>
     <script>
       var options = {
         'content': 'We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.',

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-
+{% block description %}{{ post.summary | striptags | urlize(30, true) }}{% endblock %}
 {% block body %}
 {% if request.args.get('newsletter') == 'true' %}
 <div class="p-strip--light is-shallow">

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -50,7 +50,7 @@
         {% if post.featuredmedia and post.featuredmedia.source_url %}
         <div class="u-crop--16-9">
           <a href="{{post.link}}">
-            <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+            <img decoding="async" src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
             srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
                     https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
                     https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"

--- a/templates/press-centre.html
+++ b/templates/press-centre.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Press centre{% endblock %}
+{% block description %}The home of Ubuntu media resources, news stories and press releases.{% endblock %}
 {% block body %}
 
   <section class="p-strip--image is-dark p-strip--suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/dc337e68-image-partners.jpg')">

--- a/templates/topics.html
+++ b/templates/topics.html
@@ -10,16 +10,15 @@
             <img class="p-topic-image" src="{{ topic.logo_url }}" alt=""/>
             {% else %}
             <img class="p-heading-icon__img" src="{{ topic.logo_url }}" alt=""/>
-            <h1 class="p-heading--one p-heading-icon__title">{{ topic.name }}</h1>
+            <h1 class="p-heading--one p-heading-icon__title">{% block title %}{{ topic.name }}{% endblock %}</h1>
             {% endif %}
           </div>
           <h2 class="p-heading--two">{{ topic.subtitle }}</h2>
-          <p class="p-heading--five">{{ topic.description | safe }}</p>
+          <p class="p-heading--five">{% block description %}{{ topic.description | safe }}{% endblock %}</p>
         </div>
-          <p>
-            <a class="p-link--external{% if topic.strip_css == 'p-strip--accent is-dark' %} p-link--inverted{% endif %}" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
-          </p>
-        </ul>
+        <p>
+          <a class="p-link--external{% if topic.strip_css == 'p-strip--accent is-dark' %} p-link--inverted{% endif %}" href="{{ topic.url }}">Learn more about {{ topic.name }}</a>
+        </p>
       </div>
       <div class="col-5 prefix-1">
         <img src="{{ topic.hero_url }}"

--- a/templates/topics/design.html
+++ b/templates/topics/design.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Design{% endblock %}
+{% block description %}All the latest news on the design team at Canonical{% endblock %}
 {% block body %}
 
   <div class="p-strip is-shallow is-bordered u-image-position" style="overflow: hidden;">
@@ -9,13 +11,11 @@
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt=""/>
             <h1 class="p-heading--one u-no-margin--top">Design</h1>
           </div>
-          <h2 class="p-heading--two">Branding and web development</h2>
           <p class="p-heading--five">All the latest news on the design team at Canonical.</p>
         </div>
-          <p>
-            <a class="p-link--external" href="https://design.ubuntu.com">Learn more about Design</a>
-          </p>
-        </ul>
+        <p>
+          <a class="p-link--external" href="https://design.ubuntu.com">Learn more about Design</a>
+        </p>
       </div>
       <div class="col-5 prefix-1">
         <img

--- a/templates/topics/juju.html
+++ b/templates/topics/juju.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Juju and JAAS{% endblock %}
+{% block description %}Operate big software at scale on any cloud. All the latest news on Juju – the open source application modelling tool for public and private clouds.{% endblock %}
 {% block body %}
 
   <div class="p-strip--accent is-dark is-shallow is-bordered u-image-position" style="overflow: hidden;">
@@ -11,10 +13,9 @@
           <h2 class="p-heading--two">Operate big software at scale on any cloud</h2>
           <p class="p-heading--five">All the latest news on Juju – the open source application modelling tool for public and private clouds.</p>
         </div>
-          <p>
-            <a class="p-link--external p-link--inverted" href="https://jujucharms.com">Learn more about Juju</a>
-          </p>
-        </ul>
+        <p>
+          <a class="p-link--external p-link--inverted" href="https://jujucharms.com">Learn more about Juju</a>
+        </p>
       </div>
       <div class="col-5 prefix-1">
         <img

--- a/templates/topics/maas.html
+++ b/templates/topics/maas.html
@@ -1,4 +1,7 @@
 {% extends "layout.html" %}
+{% block title %}MAAS{% endblock %}
+{% block description %}All the latest news on MAAS (Metal as a Service) - the smartest way to manage bare metal.{% endblock %}
+
 {% block body %}
 
 
@@ -12,10 +15,9 @@
           <h2 class="p-heading--two">Metal as a Service</h2>
           <p class="p-heading--five">All the latest news on MAAS – the smartest way to manage bare metal.</p>
         </div>
-          <p>
-            <a class="p-link--external p-link--inverted" href="https://maas.io">Learn more about MAAS</a>
-          </p>
-        </ul>
+        <p>
+          <a class="p-link--external p-link--inverted" href="https://maas.io">Learn more about MAAS</a>
+        </p>
       </div>
       <div class="col-5 prefix-1">
         <img

--- a/templates/topics/snappy.html
+++ b/templates/topics/snappy.html
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
+{% block title %}Snapcraft and Snaps{% endblock %}
+{% block description %}Package any app for any Linux and deliver updates directly. All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.{% endblock %}
 {% block body %}
 
   <div class="p-strip--accent is-dark is-shallow is-bordered u-image-position" style="overflow: hidden;">
@@ -11,10 +13,9 @@
           <h2 class="p-heading--two">Package any app for any Linux and deliver updates directly</h2>
           <p class="p-heading--five">All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>
         </div>
-          <p>
-            <a class="p-link--external p-link--inverted" href="https://snapcraft.io">Learn more about Snapcraft</a>
-          </p>
-        </ul>
+        <p>
+          <a class="p-link--external p-link--inverted" href="https://snapcraft.io">Learn more about Snapcraft</a>
+        </p>
       </div>
       <div class="col-5 prefix-1">
         <img

--- a/templates/upcoming_posts.html
+++ b/templates/upcoming_posts.html
@@ -14,7 +14,7 @@
       {% if post.featuredmedia and post.featuredmedia.source_url %}
       <div class="u-crop--16-9">
         <a href="{{post.link}}">
-          <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
+          <img decoding="async" src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}}"
             srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{post.featuredmedia.source_url}} 460w,
                     https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{post.featuredmedia.source_url}} 620w,
                     https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{post.featuredmedia.source_url}} 875w"

--- a/templates/whats-coming-up.html
+++ b/templates/whats-coming-up.html
@@ -3,7 +3,7 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h5>Upcoming events and webinars</h5>
+      <h5>{% block title %}Upcoming events and webinars{% endblock %}</h5>
     </div>
   </div>
 


### PR DESCRIPTION
## Done

- added more/better meta-data tags and cleaned up each page type's metadata
- made posts.html images async
- made javascript async

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- see that there is good metadata and titles for all post types
- see that images on the homepage and in posts, below the fold load 

