### PR TITLE
Fix the async javascript plugins

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -109,17 +109,19 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
       </footer>
     </div>
-    <script src="/static/js/modules/cookie-policy.js" async></script>
     <script src="/static/js/aria-controls.js" async></script>
     <script src="/static/js/search.js" async></script>
-    <script src="/static/js/modules/global.js" async></script>
+    <script src="/static/js/modules/cookie-policy.js" defer></script>
+    <script src="/static/js/modules/global.js" defer></script>
     <script>
-      var options = {
-        'content': 'We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.',
-        'duration': 5000
-      }
-      ubuntu.cookiePolicy.setup(options);
-      ubuntu.globalNav.setup();
+      document.addEventListener("DOMContentLoaded", function(event) {
+        var options = {
+          'content': 'We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.',
+          'duration': 5000
+        }
+        ubuntu.cookiePolicy.setup(options);
+        ubuntu.globalNav.setup();
+      });
     </script>
 
     <!-- RTP tag -->


### PR DESCRIPTION
## Done
Fix the loading order to the called functions in required plugins.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Go to any page and see the global nav loads
- Check there are no js errors
