### PR TITLE
Display the third post on the homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,6 +161,12 @@ def homepage():
         sticky=False,
     )
 
+    ## Manipulate the posts to add a newsletter placeholder
+    if page == 1:
+        print('page: ' + str(page))
+        posts.insert(2, 'newsletter')
+        posts.pop(11)
+
     return flask.render_template(
         "index.html",
         posts=posts,

--- a/app.py
+++ b/app.py
@@ -161,7 +161,7 @@ def homepage():
         sticky=False,
     )
 
-    ## Manipulate the posts to add a newsletter placeholder
+    # Manipulate the posts to add a newsletter placeholder
     if page == 1:
         print('page: ' + str(page))
         posts.insert(2, 'newsletter')

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -37,7 +37,7 @@
   {% if loop.index0 % 3 == 0 %}
   <div class="row u-equal-height u-clearfix">
   {% endif %}
-  {% if loop.index0 == 2 and current_page == 1 %}
+  {% if post == 'newsletter' and current_page == 1 %}
   <div class="col-4">
     {% include 'newsletter-form.html' %}
   </div>


### PR DESCRIPTION
## Done
Manipulated the posts list to include a placeholder for the newsletter widget.

I tried to keep it a template change but the logic becomes very complex. I am also aware this will result in a post being hidden between page 1 and page 2 but the main concern is recent posts (third one) is currently being hidden.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check the difference between the live site and this branch.
- You should see there is a difference in the third post and the other posts will remain in order but pushed by one.
- Check the pagination works

## Issue / Card
Fixes #435 
