### PR TITLE
Test the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,16 @@ defaults: &defaults
     - image: canonicalwebteam/dev
 
 jobs:
+  test-build:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: Check the site builds
+          command: yarn build
   python-tests:
     <<: *defaults
     steps:
@@ -37,6 +47,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - test-build
       - scss-lint
       - python-lint
       - python-tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "yarn run lint-scss && yarn run lint-py && yarn run test-py",
+    "test": "yarn run build && yarn run lint-scss && yarn run lint-py && yarn run test-py",
     "lint-py": "flake8 --exclude '*env*,node_modules'",
     "lint-scss": "sass-lint 'static/**/*.scss' --verbose --no-exit",
     "test-py": "python3 -m unittest discover tests",


### PR DESCRIPTION
For both `./run test` and the CircleCI tests, we should test
that the build succeeds.

This would provide more transparency over the state of Renovate
upgrade PRs, e.g.:

https://github.com/canonical-websites/blog.ubuntu.com/pull/463

QA
--

Run `./run test`, check it succeeds. Also check CI tests succeed.