### PR TITLE
Replace "test-build" CI job with "test-site"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,23 @@ defaults: &defaults
     - image: canonicalwebteam/dev
 
 jobs:
-  test-build:
+  test-site:
     <<: *defaults
     steps:
       - checkout
       - run:
           name: Install dependencies
-          command: yarn
+          command: yarn && pip3 install -r requirements.txt
       - run:
-          name: Check the site builds
-          command: yarn build
+          name: Build the site resources
+          command: yarn run build
+      - run:
+          name: Run the site server
+          command: ./entrypoint 0.0.0.0:80
+          background: true
+      - run:
+          name: Check site is accessible
+          command: sleep 1 && curl --head --fail --retry-delay 5 --retry 10  --retry-connrefused http://localhost
   python-tests:
     <<: *defaults
     steps:
@@ -47,7 +54,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - test-build
+      - test-site
       - scss-lint
       - python-lint
       - python-tests


### PR DESCRIPTION
This goes one step beyond just testing the build,
instead, it tests the site can be both built and served correctly,
and that the site can then be accessed, returning a status
code of <400.

QA
--

Check the "test-site" CI step exists, and passes.

Also, check the site does actually run with `./run` as usual.