### PR TITLE
Exclude lang-jp tagged posts from API results

### DIFF
--- a/api.py
+++ b/api.py
@@ -67,6 +67,8 @@ def get_posts(
     group_ids=[],
     category_ids=[],
     tag_ids=[],
+    # Exclude "lang:jp" tagged posts
+    tags_exclude_ids=[3184],
     author_ids=[],
     before=None,
     after=None,
@@ -95,6 +97,7 @@ def get_posts(
                 "group": helpers.join_ids(group_ids),
                 "categories": helpers.join_ids(category_ids),
                 "tags": helpers.join_ids(tag_ids),
+                "tags_exclude": helpers.join_ids(tags_exclude_ids),
                 "author": helpers.join_ids(author_ids),
                 "before": before.isoformat() if before else None,
                 "after": after.isoformat() if after else None,


### PR DESCRIPTION
## Done

* Globally exclude lang:jp tagged posts from API results, therefore from any page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Ensure you see "Easy IoT with Ubuntu Core and Raspberry Pi" on the homepage
- On line 71, replace 3184 ("lang:jp" tag id) by 2598 ("Development" tag id)
- Ensure "Easy IoT with Ubuntu Core and Raspberry Pi" is gone from the homepage.
