### PR TITLE
Revert cache backed to memory

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -35,7 +35,7 @@ request_latency_seconds = prometheus_client.Histogram(
 cached_session = requests_cache.CachedSession(
     name="hour-cache",
     expire_after=datetime.timedelta(hours=1),
-    backend="sqlite",
+    backend="memory",
     old_data_on_error=True,
 )
 cached_session.mount(


### PR DESCRIPTION
## Done

- Revert the cache backend from "sqlite" to "memory" to attempt to make the site more performant (currently page loads are over 20 seconds).

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that the home page loads in less than 10 seconds