### PR TITLE
Add preconnect links to important third-party origins

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,6 +2,12 @@
 
 <html lang="en">
   <head>
+
+    <!-- Preconnect to establish early connections to important third-party origins -->
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="www.googletagmanager.com">
+    <link rel="preconnect" href="https://assets.ubuntu.com">
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Done

- GA
- Google Tag Manager
- Assets Server

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check `<link>`s appear in view source