### PR TITLE
Use correct cookie-policy namespace

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -122,7 +122,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           'content': 'We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.',
           'duration': 5000
         }
-        ubuntu.cookiePolicy.setup(options);
+        cpNs.cookiePolicy.setup(options);
       });
     </script>
 


### PR DESCRIPTION
## Done

Use correct cookie-policy namespace - this was a breaking change in recent `cookie-policy` upgrade.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- You should no longer see this `ubuntu is not defined` (2) error in the console
<img width="1440" alt="screenshot 2019-03-01 at 11 37 14" src="https://user-images.githubusercontent.com/505570/53632930-6dc3b400-3c16-11e9-8451-a3ce934bab1c.png">


