### PR TITLE
Add redirect for 14.04 article

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -27,3 +27,6 @@
 
 # alternative homepage used for a/b test
 /home?: /
+
+# specific article redirects
+/2019/02/05/ubuntu-14-04-trusty-tahr-end-of-life/?: /2019/02/05/ubuntu-14-04-trusty-tahr


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/2019/02/05/ubuntu-14-04-trusty-tahr-end-of-life](http://0.0.0.0:8023/2019/02/05/ubuntu-14-04-trusty-tahr-end-of-life)
- see that you are redirected to http://0.0.0.0:8023/2019/02/05/ubuntu-14-04-trusty-tahr

## Issue / Card

Fixes #501
