### PR TITLE
Strip html from the og:description tag

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -34,7 +34,7 @@
     {% endif %}
 
       <meta name="description" content="{% block description %}Your source for Ubuntu news, articles, tutorials, e-books and everything else in-between.{% endblock %}" />
-      <meta property="og:description" content="{{ self.description() }}" />
+      <meta property="og:description" content="{{ self.description() | striptags }}" />
 
     {% if post and post.featuredmedia %}
       <meta property="og:image" content="{{post.featuredmedia.source_url}}" />


### PR DESCRIPTION
## Done

- added fluid striphtml filter to og tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/2018/02/27/charming-discourse-with-the-reactive-framework](http://0.0.0.0:8023/2018/02/27/charming-discourse-with-the-reactive-framework)
- see that you don't see the html at the top of the page

## Issue / Card

Fixes #507

## Screenshots

orig
![image](https://user-images.githubusercontent.com/441217/55215215-e8212d00-51f0-11e9-8d7b-b56b3a8a19c3.png)

new
![image](https://user-images.githubusercontent.com/441217/55215190-d0e23f80-51f0-11e9-9dd7-022c37e66965.png)
