### PR TITLE
Add the robotics newsletter option

### DIFF
--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -19,6 +19,10 @@
           <label for="insightsiot">Internet of Things</label>
         </li>
         <li class="p-list__item u-no-margin--top u-clearfix">
+          <input class="" type="checkbox" id="insightsrobotics" name="insightsrobotics" value="Robotics" />
+          <label for="insightsrobotics">Robotics</label>
+        </li>
+        <li class="p-list__item u-no-margin--top u-clearfix">
           <input id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
           <label for="insightstutorials">Tutorials</label>
         </li>


### PR DESCRIPTION
## Done
Add robotics option to the newsletter sign up form

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check that the sign up form on the right has the robotics option
- Check the id and name of the field is `insightsrobotics`

## Issue / Card
Fixes https://github.com/canonical-websites/blog.ubuntu.com/issues/509
