### PR TITLE
Add the robotics topics page

### DIFF
--- a/app.py
+++ b/app.py
@@ -277,6 +277,15 @@ def snappy():
     )
 
 
+@app.route("/topics/robotics")
+def robotics():
+    return _tag_view(
+        tag_slug="robotics",
+        page_slug="topics",
+        template="topics/robotics.html"
+    )
+
+
 @app.route("/archives")
 def archives():
     page = helpers.to_int(flask.request.args.get("page"), default=1)

--- a/app.py
+++ b/app.py
@@ -282,7 +282,7 @@ def robotics():
     return _tag_view(
         tag_slug="robotics",
         page_slug="topics",
-        template="topics/robotics.html"
+        template="topics/robotics.html",
     )
 
 

--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -53,6 +53,7 @@
           <li class="p-navigation__link"><a href="/topics/juju">Juju</a></li>
           <li class="p-navigation__link"><a href="/topics/maas">MAAS</a></li>
           <li class="p-navigation__link"><a href="/topics/snappy">Snappy</a></li>
+          <li class="p-navigation__link"><a href="/topics/robotics">Robotics</a></li>
         </ul>
       </div>
     </li>
@@ -102,6 +103,7 @@
         <li><a href="/topics/juju">Juju</a></li>
         <li><a href="/topics/maas">MAAS</a></li>
         <li><a href="/topics/snappy">Snapcraft</a></li>
+        <li><a href="/topics/robotics">Robotics</a></li>
       </ul>
     </li>
     <li class="p-navigation__link{%- if page_slug == 'press-centre' %} is-selected{% endif %}">

--- a/templates/topics/robotics.html
+++ b/templates/topics/robotics.html
@@ -17,7 +17,7 @@
           <a class="p-link--external" href="https://wwww.ubuntu.com/internet-of-things/robotics">Learn more about robotics from Canonical</a>
         </p>
       </div>
-      <div class="col-5 prefix-1 u-align--center u-vertically-center">
+      <div class="col-5 prefix-1 u-align--center u-vertically-center u-hide--small">
         <img src="https://assets.ubuntu.com/v1/5b16cbb9-robot_2px.svg" alt="" />
       </div>
     </div>

--- a/templates/topics/robotics.html
+++ b/templates/topics/robotics.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% block title %}Robotics{% endblock %}
+{% block description %}All the latest news on robotics from Canonical{% endblock %}
+{% block body %}
+
+  <div class="p-strip is-shallow is-bordered">
+    <div class="row u-equal-height">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt=""/>
+            <h1 class="p-heading--one u-no-margin--top">Robotics</h1>
+          </div>
+          <p class="p-heading--five">Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
+        </div>
+        <p>
+          <a class="p-link--external" href="https://wwww.ubuntu.com/internet-of-things/robotics">Learn more about robotics from Canonical</a>
+        </p>
+      </div>
+      <div class="col-5 prefix-1 u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/5b16cbb9-robot_2px.svg" alt="" />
+      </div>
+    </div>
+  </div>
+
+  {% include "posts.html" %}
+
+  {% include "pagination.html" %}
+
+{% endblock %}


### PR DESCRIPTION
## Done
Add the robotics topics page with a mocked up header

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Open the topics menu and click Robotics
- Check the page loads a set a robotics posts
- Check header looks ok

## Issue / Card
Fixes https://github.com/canonical-websites/blog.ubuntu.com/issues/511
