### PR TITLE
Configure session with talisker

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urlunparse, unquote
 # Third-party
 import flask
 import talisker.flask
+import talisker.requests
 from dateutil.relativedelta import relativedelta
 
 # Local
@@ -22,6 +23,9 @@ app.jinja_env.filters["monthname"] = helpers.monthname
 app.url_map.strict_slashes = False
 app.url_map.converters["regex"] = helpers.RegexConverter
 talisker.flask.register(app)
+
+if not app.testing:
+    talisker.requests.configure(feeds.cached_session)
 
 apply_redirects = redirects.prepare_redirects(
     permanent_redirects_path="permanent-redirects.yaml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ Werkzeug==0.15.2
 yamlordereddictloader==0.4.0
 pyyaml==5.1
 raven[flask]==6.10.0
-prometheus_client==0.6.0
 talisker[gunicorn]==0.14.2


### PR DESCRIPTION
## Done

- configure session to get prometheus infor from talisker configuration.

## QA

- Check out this feature branch
- create file `.env.local` with this line: `TALISKER_NETWORKS=172.17.0.1`
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- go on http://0.0.0.0:8023/_status/metrics
- Make sure you have the new metrics: `wsgi_latency_bucket`, `requests_latency_bucket`

## Issue / Card

Fixes https://github.com/ubuntudesign/base-squad/issues/370
