### PR TITLE
Exclude chinese posts

### DIFF
--- a/api.py
+++ b/api.py
@@ -67,8 +67,8 @@ def get_posts(
     group_ids=[],
     category_ids=[],
     tag_ids=[],
-    # Exclude "lang:jp" tagged posts
-    tags_exclude_ids=[3184],
+    # Exclude "lang:jp, lang:cn" tagged posts
+    tags_exclude_ids=[3184, 3265],
     author_ids=[],
     before=None,
     after=None,


### PR DESCRIPTION
## Done

- Adds chinese tag number to excluded tags

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Make sure that no chinese posts show up (e.g. `blog/ubuntu19-04-release-cn`)

