### PR TITLE
Add cta for all robotics blog posts

### DIFF
--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -69,5 +69,6 @@
   .p-strip--cta {
     background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
     color: $color-light;
+    padding: 3em 0 !important;
   }
 }

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -69,6 +69,6 @@
   .p-strip--cta {
     background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
     color: $color-light;
-    padding: 3em 0 !important;
+    padding: $spv-inter--regular-scaleable 0 !important;
   }
 }

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -1,6 +1,7 @@
 @mixin blog-p-strips {
   @include blog-p-strips-suru;
   @include blog-p-strips-featured;
+  @include blog-p-strips-cta;
 }
 
 @mixin blog-p-strips-suru {
@@ -61,5 +62,12 @@
         background-position: top right;
       }
     }
+  }
+}
+
+@mixin blog-p-strips-cta {
+  .p-strip--cta {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    color: $color-light;
   }
 }

--- a/static/sass/_pattern_strips.scss
+++ b/static/sass/_pattern_strips.scss
@@ -1,7 +1,6 @@
 @mixin blog-p-strips {
   @include blog-p-strips-suru;
   @include blog-p-strips-featured;
-  @include blog-p-strips-cta;
 }
 
 @mixin blog-p-strips-suru {
@@ -62,13 +61,5 @@
         background-position: top right;
       }
     }
-  }
-}
-
-@mixin blog-p-strips-cta {
-  .p-strip--cta {
-    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
-    color: $color-light;
-    padding: $spv-inter--regular-scaleable 0 !important;
   }
 }

--- a/templates/post.html
+++ b/templates/post.html
@@ -91,6 +91,25 @@
     </div>
   </div>
 </div>
+{% for tag in tags %}
+  {% if tag.slug == 'robotics' %}
+    <div class="p-strip--cta is-deep">
+      <div class="row">
+        <div class="col-8">
+          <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>
+          <p>
+            <a href="https://www.ubuntu.com/internet-of-things/contact-us?product=robotics" class="p-button--positive">
+              Contact Us
+            </a>
+          </p>
+        </div>
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
+          <img width="100" src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="" />
+        </div>
+      </div>  
+    </div>
+  {% endif %}
+{% endfor %}
 <div class="p-strip--light is-shallow">
   <div class="row">
     <div class="col-8">

--- a/templates/post.html
+++ b/templates/post.html
@@ -93,7 +93,8 @@
 </div>
 {% for tag in tags %}
   {% if tag.slug == 'robotics' %}
-    <div class="p-strip--cta">
+    <div class="p-strip--image is-dark" 
+      style="background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);">
       <div class="row">
         <div class="col-8">
           <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>

--- a/templates/post.html
+++ b/templates/post.html
@@ -93,7 +93,7 @@
 </div>
 {% for tag in tags %}
   {% if tag.slug == 'robotics' %}
-    <div class="p-strip--cta is-deep">
+    <div class="p-strip--cta">
       <div class="row">
         <div class="col-8">
           <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>


### PR DESCRIPTION
## Done

Add cta for all robotics blog posts 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/topics/robotics](http://0.0.0.0:8023/topics/robotics)
- Open any robotics related post and check the cta
- The cta should be visible on the robotics related posts only
- Check the [design](https://github.com/canonical-web-and-design/blog.ubuntu.com/issues/518)



## Issue / Card

Fixes [#510](https://github.com/canonical-web-and-design/blog.ubuntu.com/issues/510)

