### PR TITLE
436 sharing links go to the homepage

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -42,17 +42,17 @@
           Share on:
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered | safe | urlencode }}&amp;p[summary]={{ post.summary | safe | urlencode}}%26hellip%3B&amp;p[images][0]=">
+          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com{{ post.link }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered | safe | urlencode }}&amp;p[summary]={{ post.summary | safe | urlencode}}%26hellip%3B&amp;p[images][0]=">
             Facebook
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe | urlencode }}&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;hashtags=ubuntu">
+          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe | urlencode }}&amp;url=https://blog.ubuntu.com{{ post.link }}&amp;hashtags=ubuntu">
             Twitter
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe | urlencode }}">
+          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com{{ post.link }}&amp;title={{ post.title.rendered | safe | urlencode }}">
           LinkedIn
         </a>
         </li>


### PR DESCRIPTION
## Done

Update twitter share content link to take you to the post page instead of home page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Go to a blog post
- Click the Twitter share icon
- Check the generated link takes you to the post page


## Issue / Card

Fixes [436](https://github.com/canonical-web-and-design/blog.ubuntu.com/issues/436)

