### PR TITLE
Deal with missing or bad data

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -85,7 +85,7 @@
     border-bottom: 0;
     border-top: 3px solid #666666;
     margin-bottom: 0;
-    padding: 1rem 1rem .5rem;
+    padding: $sp-medium $sp-medium $sp-small;
 
     &--cloud-and-server {
       @extend %post-card-header;

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -82,6 +82,10 @@
 
   .p-card__header {
     @extend %post-card-header;
+    border-bottom: 0;
+    border-top: 3px solid #e7e7e7;
+    margin-bottom: 0;
+    padding: 1rem 1rem .5rem;
 
     &--cloud-and-server {
       @extend %post-card-header;

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -83,7 +83,7 @@
   .p-card__header {
     @extend %post-card-header;
     border-bottom: 0;
-    border-top: 3px solid #e7e7e7;
+    border-top: 3px solid #666666;
     margin-bottom: 0;
     padding: 1rem 1rem .5rem;
 

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -43,8 +43,8 @@
   </div>
   {% else %}
     <div class="col-4 p-card--post">
-      <header class="p-card__header--{{ post.group.slug }}">
-        <h5 class="p-muted-heading">{{ post.group.name }}</h5>
+      <header class="p-card__header p-card__header--{{ post.group.slug }}">
+        <h5 class="p-muted-heading">{% if post.group.name %}{{ post.group.name }}{% else %}Ubuntu{% endif %}</h5>
       </header>
       <div class="p-card__content">
         {% if post.featuredmedia and post.featuredmedia.source_url %}

--- a/templates/singular-category.html
+++ b/templates/singular-category.html
@@ -8,6 +8,8 @@
   Webinar
 {% elif post.category.name == 'White papers' %}
   White paper
-{% else %}
+{% elif post.category.name %}
   {{ post.category.name }}
+{% else %}
+  Article
 {% endif %}


### PR DESCRIPTION
## Done

- make headers work with categories that do not exist
- make headers work with null categories defaulting to 'Ubuntu'
- make footers add 'Article' if they do not have a type

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- See that people and culture works ok
- See that footers default to text


## Issue / Card

Fixes #517

## Screenshots

**Header**
![image](https://user-images.githubusercontent.com/441217/56725456-ca3dde00-6744-11e9-881d-fd6686820ffc.png)

**Footer**
![image](https://user-images.githubusercontent.com/441217/56725810-7bdd0f00-6745-11e9-8197-5f2b3467868d.png)


