### PR TITLE
Channge "snappy" to "snapcraft" in the nav

### DIFF
--- a/templates/main-nav.html
+++ b/templates/main-nav.html
@@ -52,7 +52,7 @@
           <li class="p-navigation__link"><a href="/topics/design">Design</a></li>
           <li class="p-navigation__link"><a href="/topics/juju">Juju</a></li>
           <li class="p-navigation__link"><a href="/topics/maas">MAAS</a></li>
-          <li class="p-navigation__link"><a href="/topics/snappy">Snappy</a></li>
+          <li class="p-navigation__link"><a href="/topics/snappy">Snapcraft</a></li>
           <li class="p-navigation__link"><a href="/topics/robotics">Robotics</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Channge "snappy" to "snapcraft" in the nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Make sure the navigation menu is the consistent on both big and small screens


## Issue / Card

Fixes #519 
