### PR TITLE
Use xmltodict to strip foreign language content from the RSS feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse, urlunparse, unquote
 import flask
 import talisker.flask
 import talisker.requests
+import xmltodict
 from dateutil.relativedelta import relativedelta
 
 # Local
@@ -363,7 +364,17 @@ def feed(type=None, slug=None):  # noqa
         "admin.insights.ubuntu.com", "insights.ubuntu.com"
     )
 
-    return flask.Response(feed_text, mimetype="text/xml")
+    feed = xmltodict.parse(feed_text)
+
+    new_feed = feed.copy()
+    for index, item in enumerate(feed["rss"]["channel"]["item"]):
+        for category in item["category"]:
+            if "lang:cn" in category or "lang:jp" in category:
+                del new_feed["rss"]["channel"]["item"][index]
+
+    return flask.Response(
+        xmltodict.unparse(new_feed, pretty=True), mimetype="text/xml"
+    )
 
 
 @app.route("/author/<slug>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ urllib3==1.25.2
 Werkzeug==0.15.2
 yamlordereddictloader==0.4.0
 pyyaml==5.1
+xmltodict==0.12.0
 raven[flask]==6.10.0
 talisker[gunicorn]==0.14.2


### PR DESCRIPTION
## Done

- Removes **chinese** and **japanese** content from the RSS feed received from Wordpress

## QA

- `./run`
- head to http://localhost:8023/feed
- make sure that the feed does not contain Japanese or chinese content

## Issue / Card

Fxies https://github.com/canonical-web-and-design/blog.ubuntu.com/issues/496

