### PR TITLE
Add service name in logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urlunparse, unquote
 # Third-party
 import flask
 import talisker.flask
+import talisker.logs
 import talisker.requests
 import xmltodict
 from dateutil.relativedelta import relativedelta
@@ -24,6 +25,7 @@ app.jinja_env.filters["monthname"] = helpers.monthname
 app.url_map.strict_slashes = False
 app.url_map.converters["regex"] = helpers.RegexConverter
 talisker.flask.register(app)
+talisker.logs.set_global_extra({"service": "blog.ubuntu.com"})
 
 if not app.testing:
     talisker.requests.configure(feeds.cached_session)


### PR DESCRIPTION
## Done

Add service name in logs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- make sure logs have `service=blog.ubuntu.com`